### PR TITLE
Support Optimistic Concurrency

### DIFF
--- a/GraphQL.Net.sln
+++ b/GraphQL.Net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GraphQL.Net", "GraphQL.Net\GraphQL.Net.csproj", "{530742A1-10D8-4255-837D-43D57B00EE50}"
 EndProject

--- a/Tests.EF/App.config
+++ b/Tests.EF/App.config
@@ -16,7 +16,13 @@
     <add name="DefaultConnection" connectionString="data source=tests.db" providerName="System.Data.SQLite.EF6" />
   </connectionStrings>
   <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb"/>
+      </parameters>
+    </defaultConnectionFactory>
     <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
       <provider invariantName="System.Data.SQLite" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
       <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
     </providers>

--- a/Tests.EF/EntityFrameworkMsSqlTests.cs
+++ b/Tests.EF/EntityFrameworkMsSqlTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Data.Entity;
 using System.Linq;
@@ -72,6 +73,7 @@ namespace Tests.EF
             user.AddField(u => u.Name);
             user.AddField(u => u.Account);
             user.AddField(u => u.NullRef);
+            user.AddField(u => u.ServerTimestamp);
             user.AddField("total", (db, u) => db.Users.Count());
             user.AddField("accountPaid", (db, u) => u.Account.Paid);
             user.AddPostField("abc", () => GetAbcPostField());
@@ -198,13 +200,16 @@ namespace Tests.EF
             [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
             public Guid? Id { get; set; }
             public string Name { get; set; }
-            public bool Active { get; set; }
+            public bool Active { get; set; } 
 
             public int AccountId { get; set; }
             public Account Account { get; set; }
 
             public int? NullRefId { get; set; }
             public NullRef NullRef { get; set; }
+
+            [Timestamp]
+            public byte[] ServerTimestamp { get; set; }
         }
 
         public class Account

--- a/Tests.EF/EntityFrameworkMsSqlTests.cs
+++ b/Tests.EF/EntityFrameworkMsSqlTests.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data.Entity;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GraphQL.Net;
+using NUnit.Framework;
+using Tests.EF.Migrations;
+
+namespace Tests.EF
+{
+    [TestFixture]
+    public class EntityFrameworkMsSqlTests
+    {
+        [OneTimeSetUp]
+        public static void Init()
+        {
+            using (var db = new EfContext())
+            {
+                if (db.Accounts.Any())
+                    return;
+
+                var account = new Account
+                {
+                    Name = "My Test Account",
+                    Paid = true,
+                    PaidUtc = new DateTime(2016, 1, 1),
+                };
+                db.Accounts.Add(account);
+                var user = new User
+                {
+                    Name = "Joe User",
+                    Account = account,
+                    Active = true,
+                };
+                db.Users.Add(user);
+                var account2 = new Account
+                {
+                    Name = "Another Test Account",
+                    Paid = false
+                };
+                db.Accounts.Add(account2);
+                var user2 = new User
+                {
+                    Name = "Late Paying User",
+                    Account = account2
+                };
+                db.Users.Add(user2);
+                db.MutateMes.Add(new MutateMe());
+                db.SaveChanges();
+            }
+        }
+
+        private static GraphQL<EfContext> CreateDefaultContext()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            schema.AddScalar(new { year = 0, month = 0, day = 0 }, ymd => new DateTime(ymd.year, ymd.month, ymd.day));
+            InitializeUserSchema(schema);
+            InitializeAccountSchema(schema);
+            InitializeMutationSchema(schema);
+            InitializeNullRefSchema(schema);
+            schema.Complete();
+            return new GraphQL<EfContext>(schema);
+        }
+
+        private static void InitializeUserSchema(GraphQLSchema<EfContext> schema)
+        {
+            var user = schema.AddType<User>();
+            user.AddField(u => u.Id);
+            user.AddField(u => u.Name);
+            user.AddField(u => u.Account);
+            user.AddField(u => u.NullRef);
+            user.AddField("total", (db, u) => db.Users.Count());
+            user.AddField("accountPaid", (db, u) => u.Account.Paid);
+            user.AddPostField("abc", () => GetAbcPostField());
+            user.AddPostField("sub", () => new Sub { Id = 1 });
+
+            schema.AddType<Sub>().AddField(s => s.Id);
+            schema.AddListField("users", db => db.Users);
+            schema.AddField("user", new { id = Guid.Empty }, (db, args) => db.Users.FirstOrDefault(u => u.Id == args.id));
+        }
+
+        private static string GetAbcPostField() => "easy as 123"; // mimic an in-memory function
+
+        private static void InitializeAccountSchema(GraphQLSchema<EfContext> schema)
+        {
+            var account = schema.AddType<Account>();
+            account.AddField(a => a.Id);
+            account.AddField(a => a.Name);
+            account.AddField(a => a.Paid);
+            account.AddListField(a => a.Users);
+            account.AddListField("activeUsers", (db, a) => a.Users.Where(u => u.Active));
+
+            schema.AddField("account", new { id = Guid.Empty }, (db, args) => db.Accounts.FirstOrDefault(a => a.Id == args.id));
+            schema.AddField
+                ("accountPaidBy", new { paid = default(DateTime) },
+                    (db, args) => db.Accounts.AsQueryable().FirstOrDefault(a => a.PaidUtc <= args.paid));
+        }
+
+        private static void InitializeMutationSchema(GraphQLSchema<EfContext> schema)
+        {
+            var mutate = schema.AddType<MutateMe>();
+            mutate.AddAllFields();
+
+            schema.AddField("mutateMes", new { id = Guid.Empty }, (db, args) => db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id));
+            schema.AddMutation("mutate",
+                new { id = Guid.Empty, newVal = 0 },
+                (db, args) => db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id),
+                (db, args) =>
+                {
+                    var mutateMe = db.MutateMes.First(m => m.Id == args.id);
+                    mutateMe.Value = args.newVal;
+                    db.SaveChanges();
+                });
+        }
+
+        private static void InitializeNullRefSchema(GraphQLSchema<EfContext> schema)
+        {
+            var nullRef = schema.AddType<NullRef>();
+            nullRef.AddField(n => n.Id);
+        }
+
+        [Test]
+        public void LookupSingleEntity() => GenericTests.LookupSingleEntity(CreateDefaultContext());
+        [Test]
+        public void AliasOneField() => GenericTests.AliasOneField(CreateDefaultContext());
+        [Test]
+        public void NestedEntity() => GenericTests.NestedEntity(CreateDefaultContext());
+        [Test]
+        public void NoUserQueryReturnsNull() => GenericTests.NoUserQueryReturnsNull(CreateDefaultContext());
+        [Test]
+        public void CustomFieldSubQuery() => GenericTests.CustomFieldSubQuery(CreateDefaultContext());
+        [Test]
+        public void CustomFieldSubQueryUsingContext() => GenericTests.CustomFieldSubQueryUsingContext(CreateDefaultContext());
+        [Test]
+        public void List() => GenericTests.List(CreateDefaultContext());
+        [Test]
+        public void ListTypeIsList() => GenericTests.ListTypeIsList(CreateDefaultContext());
+        [Test]
+        public void NestedEntityList() => GenericTests.NestedEntityList(CreateDefaultContext());
+        [Test]
+        public void PostField() => GenericTests.PostField(CreateDefaultContext());
+        [Test]
+        public void PostFieldSubQuery() => GenericTests.PostFieldSubQuery(CreateDefaultContext());
+        [Test]
+        public void TypeName() => GenericTests.TypeName(CreateDefaultContext());
+        [Test]
+        public void DateTimeFilter() => GenericTests.DateTimeFilter(CreateDefaultContext());
+        [Test]
+        public void EnumerableSubField() => GenericTests.EnumerableSubField(CreateDefaultContext());
+        [Test]
+        public void SimpleMutation() => GenericTests.SimpleMutation(CreateDefaultContext());
+        [Test]
+        public void NullPropagation() => GenericTests.NullPropagation(CreateDefaultContext());
+
+        [Test]
+        public void AddAllFields()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            schema.AddType<User>().AddAllFields();
+            schema.AddType<Account>().AddAllFields();
+            schema.AddField("user", new { id = Guid.Empty }, (db, args) => db.Users.FirstOrDefault(u => u.Id == args.id));
+            schema.Complete();
+
+            var gql = new GraphQL<EfContext>(schema);
+            var results = gql.ExecuteQuery("{ user(id:1) { id, name } }");
+            Test.DeepEquals(results, "{ user: { id: 1, name: 'Joe User' } }");
+        }
+
+        class Sub
+        {
+            public int Id { get; set; }
+        }
+
+        public class EfContext : DbContext
+        {
+            public EfContext() : base("GraphQLEfTests")
+            {
+
+            }
+
+            protected override void OnModelCreating(DbModelBuilder modelBuilder)
+            {                
+                Database.SetInitializer(new MigrateDatabaseToLatestVersion<EfContext, Configuration>());
+                base.OnModelCreating(modelBuilder);
+            }
+
+            public IDbSet<User> Users { get; set; }
+            public IDbSet<Account> Accounts { get; set; }
+            public IDbSet<MutateMe> MutateMes { get; set; }
+            public IDbSet<NullRef> NullRefs { get; set; }
+        }
+
+        public class User
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public Guid? Id { get; set; }
+            public string Name { get; set; }
+            public bool Active { get; set; }
+
+            public int AccountId { get; set; }
+            public Account Account { get; set; }
+
+            public int? NullRefId { get; set; }
+            public NullRef NullRef { get; set; }
+        }
+
+        public class Account
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public Guid? Id { get; set; }
+            public string Name { get; set; }
+            public bool Paid { get; set; }
+            public DateTime? PaidUtc { get; set; }
+
+            public List<User> Users { get; set; }
+        }
+
+        public class MutateMe
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public Guid? Id { get; set; }
+            public int Value { get; set; }
+        }
+
+        public class NullRef
+        {
+            [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+            public Guid? Id { get; set; }
+        }
+    }
+}

--- a/Tests.EF/Migrations/Configuration.cs
+++ b/Tests.EF/Migrations/Configuration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Entity.Migrations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.EF.Migrations
+{
+    public sealed class Configuration : DbMigrationsConfiguration<EntityFrameworkMsSqlTests.EfContext>
+    {
+        public Configuration()
+        {
+            AutomaticMigrationsEnabled = true;
+            AutomaticMigrationDataLossAllowed = true;
+        }
+    }
+}

--- a/Tests.EF/Tests.EF.csproj
+++ b/Tests.EF/Tests.EF.csproj
@@ -81,6 +81,8 @@
   </Choose>
   <ItemGroup>
     <Compile Include="EntityFrameworkExecutionTests.cs" />
+    <Compile Include="EntityFrameworkMsSqlTests.cs" />
+    <Compile Include="Migrations\Configuration.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hack MS SQL Test project again just to quickly show issue.

Attempting to support optimistic concurrency: 

http://www.asp.net/mvc/overview/getting-started/getting-started-with-ef-using-mvc/handling-concurrency-with-the-entity-framework-in-an-asp-net-mvc-application

Midway down the page - Add an Optimistic Concurrency  Property to the Department Entity

The tldr, label one of your fields with ```[Timestamp]``` with the type of ```byte[]``` and SQL will ensure optimistic concurrency.

In the hacked ms sql test project I added 
```
[Timestamp]
public byte[] ServerTimestamp { get; set; }
```
To ```User```, and tried to run ```LookupSingleEntity()```, test throws an exception trying to ```InitializeUserSchema``` when I add the ```ServerTimestamp``` field.

Stack trace:
```
System.IndexOutOfRangeException : Index was outside the bounds of the array.
   at GraphQL.Net.GraphQLField.NewInternal[TArgs](GraphQLSchema schema, String name, Func`2 exprFunc, Type fieldCLRType, Delegate mutationFunc) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLField.cs:line 72
   at GraphQL.Net.GraphQLField.New[TContext,TArgs](GraphQLSchema schema, String name, Func`2 exprFunc, Type fieldCLRType, Action`2 mutationFunc) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLField.cs:line 65
   at GraphQL.Net.GraphQLTypeBuilder`2.AddFieldInternal[TArgs,TField](String name, Func`2 exprFunc, Action`2 mutation) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLTypeBuilder.cs:line 39
   at GraphQL.Net.GraphQLTypeBuilder`2.AddField[TArgs,TField](String name, Func`2 exprFunc) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLTypeBuilder.cs:line 31
   at GraphQL.Net.GraphQLTypeBuilder`2.AddField[TArgs,TField](String name, TArgs shape, Func`2 exprFunc) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLTypeBuilder.cs:line 22
   at GraphQL.Net.GraphQLTypeBuilder`2.AddField[TField](String name, Expression`1 expr) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLTypeBuilder.cs:line 87
   at GraphQL.Net.GraphQLTypeBuilder`2.AddField[TField](Expression`1 expr) in C:\Jobs\graphql-net\GraphQL.Net\GraphQLTypeBuilder.cs:line 72
   at Tests.EF.EntityFrameworkMsSqlTests.InitializeUserSchema(GraphQLSchema`1 schema) in C:\Jobs\graphql-net\Tests.EF\EntityFrameworkMsSqlTests.cs:line 76
   at Tests.EF.EntityFrameworkMsSqlTests.CreateDefaultContext() in C:\Jobs\graphql-net\Tests.EF\EntityFrameworkMsSqlTests.cs:line 61
   at Tests.EF.EntityFrameworkMsSqlTests.LookupSingleEntity() in C:\Jobs\graphql-net\Tests.EF\EntityFrameworkMsSqlTests.cs:line 128
```