### PR TITLE
Move "Parser" organisation docs into a new README.md

### DIFF
--- a/GraphQL.Parser/Integration.txt
+++ b/GraphQL.Parser/Integration.txt
@@ -1,1 +1,0 @@
-﻿The files in the "Integration" folder are intended to make it easier to use this library from C# programs.

--- a/GraphQL.Parser/Parsing.txt
+++ b/GraphQL.Parser/Parsing.txt
@@ -1,4 +1,0 @@
-﻿The files in the "Parsing" folder define the language grammar for GraphQL documents.
-
-The goal here is to get an abstract syntax tree representation of the language, without
-concern for whether it is valid in the context of a schema.

--- a/GraphQL.Parser/README.md
+++ b/GraphQL.Parser/README.md
@@ -1,0 +1,26 @@
+## Integration
+
+The files in the "Integration" folder are intended to make it easier to use this library from C# programs.
+
+## Parsing
+
+The files in the "Parsing" folder define the language grammar for GraphQL documents.
+
+The goal here is to get an abstract syntax tree representation of the language, without concern for whether
+it is valid in the context of a schema.
+
+## Schema
+
+The files in the "Schema" folder define the interfaces and types we use to represent schemas,
+schema-validated syntax trees, and the generic schema validation logic.
+
+We represents schemas with an interface `ISchema<'s>`, where `'s` can be any type the schema wants to
+extend the AST with. The same type is used to extend fields, arguments, directives, etc. so it is
+not completely type-safe; a schema using this extension capability will likely have to implicitly
+follow rules about which subtypes of 's it puts on each AST element.
+
+## SchemaTools
+
+The files in the "SchemaTools" folder define code that, while technically not necessary for implementing a schema,
+is expected to be useful. This includes things like mapping CLR types to GraphQL scalar types or converting an AST to
+a uniform tree of selections.

--- a/GraphQL.Parser/Schema.txt
+++ b/GraphQL.Parser/Schema.txt
@@ -1,7 +1,0 @@
-﻿The files in the "Schema" folder define the interfaces and types we use to represent schemas,
-schema-validated syntax trees, and the generic schema validation logic.
-
-We represents schemas with an interface ISchema<'s>, where 's can be any type the schema wants to
-extend the AST with. The same type is used to extend fields, arguments, directives, etc. so it is
-not completely type-safe; a schema using this extension capability will likely have to implicitly
-follow rules about which subtypes of 's it puts on each AST element.

--- a/GraphQL.Parser/SchemaTools.txt
+++ b/GraphQL.Parser/SchemaTools.txt
@@ -1,3 +1,0 @@
-﻿The files in the "SchemaTools" folder define code that, while technically not necessary for implementing a schema,
-is expected to be useful. This includes things like mapping CLR types to GraphQL scalar types or converting an AST to
-a uniform tree of selections.


### PR DESCRIPTION
Not a big deal, I know - but here for you to merge/close if you'd like some reorganisation.  I found myself jumping in/out of the individual .txt files - this way, the info appears in GH when you're in the Parser folder.

(Is this the only `IQueryable`-GraphQL bridge for .NET at the mo?  Am building a .NET Core app framework currently and keen on seeing in GraphQL is a good match.)