### PR TITLE
Use |DataDirectory| in test database path

### DIFF
--- a/Tests.EF/App.config
+++ b/Tests.EF/App.config
@@ -13,7 +13,7 @@
     </assemblyBinding>
   </runtime>
   <connectionStrings>
-    <add name="DefaultConnection" connectionString="data source=tests.db" providerName="System.Data.SQLite.EF6" />
+    <add name="DefaultConnection" connectionString="data source=|DataDirectory|tests.db" providerName="System.Data.SQLite.EF6" />
   </connectionStrings>
   <entityFramework>
     <providers>


### PR DESCRIPTION
This might not be necessary (and |DataDirectory| itself isn't very well documented), but I initially had permissions issues running the tests.  I didn't look too closely, but it looked like my working directory might have been \Windows\System32 for some reason.