### PR TITLE
Support of type conditions

### DIFF
--- a/GraphQL.Net/Executor.cs
+++ b/GraphQL.Net/Executor.cs
@@ -115,10 +115,16 @@ namespace GraphQL.Net
                 var obj = field.IsPost
                     ? field.PostFieldFunc()
                     : type.GetProperty(field.Name).GetGetMethod().Invoke(queryObject, new object[] {});
-
+                
                 if (obj == null)
                 {
-                    dict.Add(key, null);
+                    // Filter fields for selections with type conditions
+                    // TODO: Check whether this field is part of the type in type conditions or not.
+                    if (map.TypeCondition == null)
+                    {
+                        dict.Add(key, null);
+                    }
+                    
                     continue;
                 }
 

--- a/GraphQL.Net/GraphQL.cs
+++ b/GraphQL.Net/GraphQL.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using GraphQL.Net.SchemaAdapters;
 using GraphQL.Parser;
 using GraphQL.Parser.Execution;
+using Microsoft.FSharp.Core;
 
 namespace GraphQL.Net
 {
@@ -37,6 +38,7 @@ namespace GraphQL.Net
             var context = DefaultExecContext.Instance; // TODO use a real IExecContext to support passing variables
             var operation = document.Operations.Single(); // TODO support multiple operations per document, look up by name
             var execSelections = context.ToExecSelections(operation.Value);
+
             var outputs = new Dictionary<string, object>();
             foreach (var execSelection in execSelections.Select(s => s.Value))
             {

--- a/GraphQL.Net/GraphQLSchema.cs
+++ b/GraphQL.Net/GraphQLSchema.cs
@@ -150,6 +150,7 @@ namespace GraphQL.Net
             }
 
             ancestorGraphQlType?.IncludedTypes.Add(graphQLType);
+            graphQLType.BaseType = ancestorGraphQlType;
         }
 
         private static void CompleteTypes(IEnumerable<GraphQLType> types)

--- a/GraphQL.Net/GraphQLType.cs
+++ b/GraphQL.Net/GraphQLType.cs
@@ -25,7 +25,7 @@ namespace GraphQL.Net
         // Returns own fields and the fields of all included types.
         public IEnumerable<GraphQLField> GetQueryFields()
         {
-            return OwnFields.Concat(IncludedTypes.SelectMany(t => t.GetQueryFields()));
+            return OwnFields.Concat(IncludedTypes.SelectMany(t => t.GetQueryFields()).Where(f => f.Name != "__typename"));
         }
     }
 }

--- a/GraphQL.Net/GraphQLType.cs
+++ b/GraphQL.Net/GraphQLType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL.Net
 {
@@ -9,16 +10,22 @@ namespace GraphQL.Net
         {
             CLRType = type;
             Name = type.Name;
-            Fields = new List<GraphQLField>();
+            OwnFields = new List<GraphQLField>();
             IncludedTypes = new List<GraphQLType>();
         }
 
         public string Name { get; set; }
         public string Description { get; set; }
-        public List<GraphQLField> Fields { get; set; }
+        public List<GraphQLField> OwnFields { get; set; }
         public List<GraphQLType> IncludedTypes { get; set; }
         public Type CLRType { get; set; }
         public Type QueryType { get; set; }
         public bool IsScalar { get; set; } // TODO: TypeKind?
+
+        // Returns own fields and the fields of all included types.
+        public IEnumerable<GraphQLField> GetQueryFields()
+        {
+            return OwnFields.Concat(IncludedTypes.SelectMany(t => t.GetQueryFields()));
+        }
     }
 }

--- a/GraphQL.Net/GraphQLType.cs
+++ b/GraphQL.Net/GraphQLType.cs
@@ -10,11 +10,13 @@ namespace GraphQL.Net
             CLRType = type;
             Name = type.Name;
             Fields = new List<GraphQLField>();
+            IncludedTypes = new List<GraphQLType>();
         }
 
         public string Name { get; set; }
         public string Description { get; set; }
         public List<GraphQLField> Fields { get; set; }
+        public List<GraphQLType> IncludedTypes { get; set; }
         public Type CLRType { get; set; }
         public Type QueryType { get; set; }
         public bool IsScalar { get; set; } // TODO: TypeKind?

--- a/GraphQL.Net/GraphQLType.cs
+++ b/GraphQL.Net/GraphQLType.cs
@@ -17,6 +17,7 @@ namespace GraphQL.Net
         public string Name { get; set; }
         public string Description { get; set; }
         public List<GraphQLField> OwnFields { get; set; }
+        public GraphQLType BaseType { get; set; }
         public List<GraphQLType> IncludedTypes { get; set; }
         public Type CLRType { get; set; }
         public Type QueryType { get; set; }
@@ -26,6 +27,12 @@ namespace GraphQL.Net
         public IEnumerable<GraphQLField> GetQueryFields()
         {
             return OwnFields.Concat(IncludedTypes.SelectMany(t => t.GetQueryFields()).Where(f => f.Name != "__typename"));
+        }
+
+        // Returns own fields and the fields of all included types.
+        public IEnumerable<GraphQLField> GetAllFieldIncludeBaseType()
+        {
+            return BaseType != null ? OwnFields.Concat(BaseType.GetAllFieldIncludeBaseType()) : OwnFields;
         }
     }
 }

--- a/GraphQL.Net/GraphQLTypeBuilder.cs
+++ b/GraphQL.Net/GraphQLTypeBuilder.cs
@@ -54,7 +54,7 @@ namespace GraphQL.Net
         // Mutation should be null UNLESS adding a mutation at the schema level
         internal GraphQLFieldBuilder<TContext, TField> AddFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
         {
-            var field = GraphQLField.New(_schema, name, exprFunc, typeof (TField));
+            var field = GraphQLField.New(_schema, name, exprFunc, typeof (TField), _type);
             _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
@@ -62,7 +62,7 @@ namespace GraphQL.Net
         // Mutation should be null UNLESS adding a mutation at the schema level
         internal GraphQLFieldBuilder<TContext, TField> AddListFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
         {
-            var field = GraphQLField.New(_schema, name, exprFunc, typeof (IEnumerable<TField>));
+            var field = GraphQLField.New(_schema, name, exprFunc, typeof (IEnumerable<TField>), _type);
             _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
@@ -70,7 +70,7 @@ namespace GraphQL.Net
         // Mutation should be null UNLESS adding a mutation at the schema level
         internal GraphQLFieldBuilder<TContext, TField> AddMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, TField>>> exprFunc, Func<TContext, TArgs, TMutReturn> mutation)
         {
-            var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (TField), mutation);
+            var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (TField), _type, mutation);
             _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
@@ -78,7 +78,7 @@ namespace GraphQL.Net
         // Mutation should be null UNLESS adding a mutation at the schema level
         internal GraphQLFieldBuilder<TContext, TField> AddListMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc, Func<TContext, TArgs, TMutReturn> mutation)
         {
-            var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (IEnumerable<TField>), mutation);
+            var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (IEnumerable<TField>), _type, mutation);
             _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
@@ -142,7 +142,7 @@ namespace GraphQL.Net
             var argsExpr = Expression.Lambda(Expression.Quote(lambda), objectParam);
             var exprFunc = argsExpr.Compile();
 
-            return GraphQLField.New(_schema, prop.Name.ToCamelCase(), (Func<object, LambdaExpression>) exprFunc, prop.PropertyType);
+            return GraphQLField.New(_schema, prop.Name.ToCamelCase(), (Func<object, LambdaExpression>) exprFunc, prop.PropertyType, _type);
         }
 
         public GraphQLFieldBuilder<TContext, TField> AddPostField<TField>(string name, Func<TField> fieldFunc)

--- a/GraphQL.Net/GraphQLTypeBuilder.cs
+++ b/GraphQL.Net/GraphQLTypeBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -149,6 +150,22 @@ namespace GraphQL.Net
             var field = GraphQLField.Post(_schema, name, fieldFunc);
             _type.Fields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
+        }
+        
+        // TODO: This could return another GraphQLTypeBuilder with less functionality, maybe nested includes should not be allowed.
+        public GraphQLTypeBuilder<TContext, TEntity> IncludeType<TEntity>(string name = null, string description = null)
+        {
+            var type = typeof(TEntity);
+            if (_type.IncludedTypes.Any(t => t.CLRType == type))
+                throw new ArgumentException("Type has already been included");
+
+            var gqlType = new GraphQLType(type) { IsScalar = type.IsPrimitive, Description = description ?? "" };
+            if (!string.IsNullOrEmpty(name))
+                gqlType.Name = name;
+
+            _type.IncludedTypes.Add(gqlType);
+
+            return new GraphQLTypeBuilder<TContext, TEntity>(_schema, gqlType);
         }
     }
 }

--- a/GraphQL.Net/GraphQLTypeBuilder.cs
+++ b/GraphQL.Net/GraphQLTypeBuilder.cs
@@ -43,8 +43,8 @@ namespace GraphQL.Net
         }
 
         // See GraphQLSchema.AddField for an explanation of the type of exprFunc, since it follows similar reasons
-        // TL:DR; Fields can have parameters passed in, so the Expression<Func> to be used is dependent on TArgs
-        //        Fields can use TContext as well, so we have to return an Expression<Func<TContext, TEntity, TField>> and replace the TContext parameter when needed
+        // TL:DR; OwnFields can have parameters passed in, so the Expression<Func> to be used is dependent on TArgs
+        //        OwnFields can use TContext as well, so we have to return an Expression<Func<TContext, TEntity, TField>> and replace the TContext parameter when needed
         public GraphQLFieldBuilder<TContext, TField> AddField<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
             => AddFieldInternal(name, exprFunc);
 
@@ -55,7 +55,7 @@ namespace GraphQL.Net
         internal GraphQLFieldBuilder<TContext, TField> AddFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
         {
             var field = GraphQLField.New(_schema, name, exprFunc, typeof (TField));
-            _type.Fields.Add(field);
+            _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
 
@@ -63,7 +63,7 @@ namespace GraphQL.Net
         internal GraphQLFieldBuilder<TContext, TField> AddListFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
         {
             var field = GraphQLField.New(_schema, name, exprFunc, typeof (IEnumerable<TField>));
-            _type.Fields.Add(field);
+            _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
 
@@ -71,7 +71,7 @@ namespace GraphQL.Net
         internal GraphQLFieldBuilder<TContext, TField> AddMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, TField>>> exprFunc, Func<TContext, TArgs, TMutReturn> mutation)
         {
             var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (TField), mutation);
-            _type.Fields.Add(field);
+            _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
 
@@ -79,7 +79,7 @@ namespace GraphQL.Net
         internal GraphQLFieldBuilder<TContext, TField> AddListMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc, Func<TContext, TArgs, TMutReturn> mutation)
         {
             var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (IEnumerable<TField>), mutation);
-            _type.Fields.Add(field);
+            _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
         }
 
@@ -126,7 +126,7 @@ namespace GraphQL.Net
         public void AddAllFields()
         {
             foreach (var prop in typeof (TEntity).GetProperties(BindingFlags.Public | BindingFlags.Instance))
-                _type.Fields.Add(CreateGenericField(prop));
+                _type.OwnFields.Add(CreateGenericField(prop));
         }
 
         // unsafe generic magic to create a GQLField instance
@@ -148,24 +148,8 @@ namespace GraphQL.Net
         public GraphQLFieldBuilder<TContext, TField> AddPostField<TField>(string name, Func<TField> fieldFunc)
         {
             var field = GraphQLField.Post(_schema, name, fieldFunc);
-            _type.Fields.Add(field);
+            _type.OwnFields.Add(field);
             return new GraphQLFieldBuilder<TContext, TField>(field);
-        }
-        
-        // TODO: This could return another GraphQLTypeBuilder with less functionality, maybe nested includes should not be allowed.
-        public GraphQLTypeBuilder<TContext, TEntity> IncludeType<TEntity>(string name = null, string description = null)
-        {
-            var type = typeof(TEntity);
-            if (_type.IncludedTypes.Any(t => t.CLRType == type))
-                throw new ArgumentException("Type has already been included");
-
-            var gqlType = new GraphQLType(type) { IsScalar = type.IsPrimitive, Description = description ?? "" };
-            if (!string.IsNullOrEmpty(name))
-                gqlType.Name = name;
-
-            _type.IncludedTypes.Add(gqlType);
-
-            return new GraphQLTypeBuilder<TContext, TEntity>(_schema, gqlType);
         }
     }
 }

--- a/GraphQL.Net/SchemaAdapters/Schema.cs
+++ b/GraphQL.Net/SchemaAdapters/Schema.cs
@@ -45,11 +45,6 @@ namespace GraphQL.Net.SchemaAdapters
 
             _queryTypes = new [] {rootTypes, includedTypes}.SelectMany(dict => dict)
                 .ToDictionary(kv => kv.Key, kv => kv.Value);
-
-            foreach (var k in _queryTypes.Keys)
-            {
-                Console.WriteLine(k);
-            }
         }
 
         public override IReadOnlyDictionary<string, ISchemaQueryType<Info>> QueryTypes

--- a/GraphQL.Net/SchemaAdapters/Schema.cs
+++ b/GraphQL.Net/SchemaAdapters/Schema.cs
@@ -33,18 +33,10 @@ namespace GraphQL.Net.SchemaAdapters
         {
             RootType = new SchemaRootType(this, schema.GetGQLType(typeof(TContext)));
             _schema = schema;
-            var rootTypes = schema.Types
+            _queryTypes = schema.Types
                 .Where(t => !t.IsScalar)
                 .Select(OfType)
                 .ToDictionary(t => t.TypeName, t => t as ISchemaQueryType<Info>);
-
-            // Add the included types
-            var includedTypes = schema.Types.SelectMany(t => t.IncludedTypes)
-                .Select(OfType)
-                .ToDictionary(t => t.TypeName, t => t as ISchemaQueryType<Info>);
-
-            _queryTypes = new [] {rootTypes, includedTypes}.SelectMany(dict => dict)
-                .ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 
         public override IReadOnlyDictionary<string, ISchemaQueryType<Info>> QueryTypes

--- a/GraphQL.Net/SchemaAdapters/SchemaRootType.cs
+++ b/GraphQL.Net/SchemaAdapters/SchemaRootType.cs
@@ -9,7 +9,7 @@ namespace GraphQL.Net.SchemaAdapters
     {
         public SchemaRootType(Schema schema, GraphQLType baseQueryType)
         {
-            Fields = baseQueryType.Fields
+            Fields = baseQueryType.OwnFields
                 .Select(f => new SchemaField(this, f, schema))
                 .ToDictionary(f => f.FieldName, f => f as ISchemaField<Info>);
         }

--- a/GraphQL.Net/SchemaAdapters/SchemaType.cs
+++ b/GraphQL.Net/SchemaAdapters/SchemaType.cs
@@ -14,7 +14,7 @@ namespace GraphQL.Net.SchemaAdapters
         internal SchemaType(GraphQLType type, Schema schema)
         {
             _type = type;
-            _fields = new Lazy<IReadOnlyDictionary<string, ISchemaField<Info>>>(() => type.Fields
+            _fields = new Lazy<IReadOnlyDictionary<string, ISchemaField<Info>>>(() => type.OwnFields
                 .Select(f => new SchemaField(this, f, schema))
                 .ToDictionary(f => f.FieldName, f => f as ISchemaField<Info>));
         }

--- a/GraphQL.Parser/Schema/SchemaResolver.fs
+++ b/GraphQL.Parser/Schema/SchemaResolver.fs
@@ -190,8 +190,8 @@ type Resolver<'s>
             failAt pos (sprintf "fragment ``%s'' is recursive" pfrag.FragmentName)
         let sub = new Resolver<'s>(schemaType, opContext, recursionDepth, pfrag.FragmentName :: fragmentContext)
         let directives = sub.ResolveDirectives(pfrag.Directives)
-        let selections = sub.ResolveSelections(pfrag.Selections)
         let typeCondition = sub.ResolveTypeCondition(pfrag.TypeCondition, pos)
+        let selections = sub.ResolveSelections(pfrag.Selections, typeCondition)
         {
             FragmentName = pfrag.FragmentName
             TypeCondition = typeCondition

--- a/GraphQL.Parser/SchemaTools/ExecSelection.fs
+++ b/GraphQL.Parser/SchemaTools/ExecSelection.fs
@@ -94,7 +94,11 @@ module private Execution =
             } |> (fun s -> { Source = selection.Source; Value = s }) |> Seq.singleton
         | FragmentSpreadSelection spread ->
             let spreadDirs = spread.Directives |> mapWithSource (execDirective context) |> toReadOnlyList
-            let subMap (sel : ExecSelection<'s>) = { sel with Directives = appendReadOnlyList sel.Directives spreadDirs }
+            let subMap (sel : ExecSelection<'s>) = 
+                { sel with 
+                    Directives = appendReadOnlyList sel.Directives spreadDirs 
+                    TypeCondition = match sel.TypeCondition with None -> spread.Fragment.TypeCondition |> Some | Some _ -> sel.TypeCondition
+                }
             spread.Fragment.Selections
             |> Seq.collect (execSelections context >> mapWithSource subMap)
         | InlineFragmentSelection frag ->

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -161,10 +161,10 @@ namespace Tests.EF
             character.AddField(c => c.Name);
             
             var human = schema.AddType<Human>();
-            human.AddField(h => (h as Human).Height);
+            human.AddField(h => h.Height);
 
             var droid = schema.AddType<Droid>();
-            droid.AddField(h => (h as Droid).PrimaryFunction);
+            droid.AddField(h => h.PrimaryFunction);
 
             schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.SingleOrDefault(h => h.Id == args.id));
             schema.AddListField("heros", db => db.Heros);

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -278,7 +278,7 @@ namespace Tests.EF
                 Database.SetInitializer(new SqliteDropCreateDatabaseWhenModelChanges<EfContext>(modelBuilder));
                 base.OnModelCreating(modelBuilder);
             }
-
+            
             public IDbSet<User> Users { get; set; }
             public IDbSet<Account> Accounts { get; set; }
             public IDbSet<MutateMe> MutateMes { get; set; }

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -294,6 +294,24 @@ namespace Tests.EF
                 );
         }
 
+        [Test]
+        public void QueryFragementWithoutTypenameField()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            InitializeCharacterSchema(schema);
+            schema.Complete();
+
+            var gql = new GraphQL<EfContext>(schema);
+            var results = gql.ExecuteQuery("{ heros { name, ... on Stormtrooper { height, specialization } } }");
+            Test.DeepEquals(
+                results,
+                "{ heros: [ " +
+                "{ name: 'Han Solo',}, " +
+                "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
+                "{ name: 'R2-D2', } ] }"
+                );
+        }
+
         class Sub
         {
             public int Id { get; set; }

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -288,7 +288,7 @@ namespace Tests.EF
             Test.DeepEquals(
                 results,
                 "{ heros: [ " +
-                "{ name: 'Han Solo', __typename: 'Human', height: 5.6430448}, " + // TODO:  The height should be removed from the expected1
+                "{ name: 'Han Solo', __typename: 'Human'}, " +
                 "{ name: 'FN-2187', __typename: 'Stormtrooper',  height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
                 "{ name: 'R2-D2', __typename: 'Droid' } ] }"
                 );

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -288,7 +288,7 @@ namespace Tests.EF
             Test.DeepEquals(
                 results,
                 "{ heros: [ " +
-                "{ name: 'Han Solo', __typename: 'Human'}, " +
+                "{ name: 'Han Solo', __typename: 'Human', height: 5.6430448}, " + // TODO:  The height should be removed from the expected1
                 "{ name: 'FN-2187', __typename: 'Stormtrooper',  height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
                 "{ name: 'R2-D2', __typename: 'Droid' } ] }"
                 );

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -276,6 +276,24 @@ namespace Tests.EF
                 );
         }
 
+        [Test]
+        public void QueryFragementWithMultiLevelInheritance()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            InitializeCharacterSchema(schema);
+            schema.Complete();
+
+            var gql = new GraphQL<EfContext>(schema);
+            var results = gql.ExecuteQuery("{ heros { name, __typename, ... on Stormtrooper { height, specialization } } }");
+            Test.DeepEquals(
+                results,
+                "{ heros: [ " +
+                "{ name: 'Han Solo', __typename: 'Human'}, " +
+                "{ name: 'FN-2187', __typename: 'Stormtrooper',  height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
+                "{ name: 'R2-D2', __typename: 'Droid' } ] }"
+                );
+        }
+
         class Sub
         {
             public int Id { get; set; }

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -159,16 +159,11 @@ namespace Tests.EF
             var character = schema.AddType<Character>();
             character.AddField(c => c.Id);
             character.AddField(c => c.Name);
-
-            //character.AddField("height", c => c is Human? (c as Human).Height : 0);
-            //character.AddField("primaryFunction", c => c is Droid ? (c as Droid).PrimaryFunction : null);
-
-            // TODO: The includeTypeBuilder should provide: AddField( TBaseType => TResult) instead of AddField(TIncludeType => TResult)
-            // so that the cast can be implemented as needed.
-            var human = character.IncludeType<Human>();
+            
+            var human = schema.AddType<Human>();
             human.AddField(h => (h as Human).Height);
 
-            var droid = character.IncludeType<Droid>();
+            var droid = schema.AddType<Droid>();
             droid.AddField(h => (h as Droid).PrimaryFunction);
 
             schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.SingleOrDefault(h => h.Id == args.id));

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -163,15 +163,13 @@ namespace Tests.EF
             //character.AddField("height", c => c is Human? (c as Human).Height : 0);
             //character.AddField("primaryFunction", c => c is Droid ? (c as Droid).PrimaryFunction : null);
 
+            // TODO: The includeTypeBuilder should provide: AddField( TBaseType => TResult) instead of AddField(TIncludeType => TResult)
+            // so that the cast can be implemented as needed.
             var human = character.IncludeType<Human>();
-            human.AddField(c => c.Id);
-            human.AddField(c => c.Name);
-            human.AddField(h => h.Height);
+            human.AddField(h => (h as Human).Height);
 
             var droid = character.IncludeType<Droid>();
-            droid.AddField(c => c.Id);
-            droid.AddField(c => c.Name);
-            droid.AddField(h => h.PrimaryFunction);
+            droid.AddField(h => (h as Droid).PrimaryFunction);
 
             schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.SingleOrDefault(h => h.Id == args.id));
             schema.AddListField("heros", db => db.Heros);

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -295,7 +295,7 @@ namespace Tests.EF
         }
 
         [Test]
-        public void QueryFragementWithoutTypenameField()
+        public void QueryInlineFragementWithoutTypenameField()
         {
             var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
             InitializeCharacterSchema(schema);
@@ -303,6 +303,24 @@ namespace Tests.EF
 
             var gql = new GraphQL<EfContext>(schema);
             var results = gql.ExecuteQuery("{ heros { name, ... on Stormtrooper { height, specialization } } }");
+            Test.DeepEquals(
+                results,
+                "{ heros: [ " +
+                "{ name: 'Han Solo',}, " +
+                "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
+                "{ name: 'R2-D2', } ] }"
+                );
+        }
+
+        [Test]
+        public void QueryFragementWithoutTypenameField()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            InitializeCharacterSchema(schema);
+            schema.Complete();
+
+            var gql = new GraphQL<EfContext>(schema);
+            var results = gql.ExecuteQuery("{ heros { name, ...stormtrooper } }, fragment stormtrooper on Stormtrooper { height, specialization } ");
             Test.DeepEquals(
                 results,
                 "{ heros: [ " +

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data.Entity;
+using System.Data.Entity.Migrations;
 using System.Linq;
+using System.Linq.Expressions;
 using GraphQL.Net;
 using NUnit.Framework;
 using SQLite.CodeFirst;
@@ -46,6 +48,22 @@ namespace Tests.EF
                 };
                 db.Users.Add(user2);
                 db.MutateMes.Add(new MutateMe());
+
+                var human = new Human
+                {
+                    Id = 1,
+                    Name = "Han Solo",
+                    Height = 5.6430448
+                };
+                db.Heros.Add(human);
+                var droid = new Droid
+                {
+                    Id = 2,
+                    Name = "R2-D2",
+                    PrimaryFunction = "Astromech"
+                };
+                db.Heros.Add(droid);
+
                 db.SaveChanges();
             }
         }
@@ -58,6 +76,7 @@ namespace Tests.EF
             InitializeAccountSchema(schema);
             InitializeMutationSchema(schema);
             InitializeNullRefSchema(schema);
+            InitializeCharacterSchema(schema);
             schema.Complete();
             return new GraphQL<EfContext>(schema);
         }
@@ -91,14 +110,14 @@ namespace Tests.EF
             account.AddField(a => a.ByteArray);
             account.AddListField(a => a.Users);
             account.AddListField("activeUsers", (db, a) => a.Users.Where(u => u.Active));
-            account.AddListField("usersWithActive", new {active = false}, (db, args, a) => a.Users.Where(u => u.Active == args.active));
-            account.AddField("firstUserWithActive", new {active = false}, (db, args, a) => a.Users.FirstOrDefault(u => u.Active == args.active));
+            account.AddListField("usersWithActive", new { active = false }, (db, args, a) => a.Users.Where(u => u.Active == args.active));
+            account.AddField("firstUserWithActive", new { active = false }, (db, args, a) => a.Users.FirstOrDefault(u => u.Active == args.active));
 
-            schema.AddField("account", new {id = 0}, (db, args) => db.Accounts.FirstOrDefault(a => a.Id == args.id));
+            schema.AddField("account", new { id = 0 }, (db, args) => db.Accounts.FirstOrDefault(a => a.Id == args.id));
             schema.AddField
                 ("accountPaidBy", new { paid = default(DateTime) },
                     (db, args) => db.Accounts.AsQueryable().FirstOrDefault(a => a.PaidUtc <= args.paid));
-            schema.AddListField("accountsByGuid", new {guid = Guid.Empty},
+            schema.AddListField("accountsByGuid", new { guid = Guid.Empty },
                     (db, args) => db.Accounts.AsQueryable().Where(a => a.SomeGuid == args.guid));
         }
 
@@ -107,9 +126,9 @@ namespace Tests.EF
             var mutate = schema.AddType<MutateMe>();
             mutate.AddAllFields();
 
-            schema.AddField("mutateMes", new {id = 0}, (db, args) => db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id));
+            schema.AddField("mutateMes", new { id = 0 }, (db, args) => db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id));
             schema.AddMutation("mutate",
-                new {id = 0, newVal = 0},
+                new { id = 0, newVal = 0 },
                 (db, args) =>
                 {
                     var mutateMe = db.MutateMes.First(m => m.Id == args.id);
@@ -118,10 +137,10 @@ namespace Tests.EF
                 },
                 (db, args) => db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id));
             schema.AddMutation("addMutate",
-                new {newVal = 0},
+                new { newVal = 0 },
                 (db, args) =>
                 {
-                    var newMutate = new MutateMe {Value = args.newVal};
+                    var newMutate = new MutateMe { Value = args.newVal };
                     db.MutateMes.Add(newMutate);
                     db.SaveChanges();
                     return newMutate.Id;
@@ -135,28 +154,73 @@ namespace Tests.EF
             nullRef.AddField(n => n.Id);
         }
 
-        [Test] public void LookupSingleEntity() => GenericTests.LookupSingleEntity(CreateDefaultContext());
-        [Test] public void AliasOneField() => GenericTests.AliasOneField(CreateDefaultContext());
-        [Test] public void NestedEntity() => GenericTests.NestedEntity(CreateDefaultContext());
-        [Test] public void NoUserQueryReturnsNull() => GenericTests.NoUserQueryReturnsNull(CreateDefaultContext());
-        [Test] public void CustomFieldSubQuery() => GenericTests.CustomFieldSubQuery(CreateDefaultContext());
-        [Test] public void CustomFieldSubQueryUsingContext() => GenericTests.CustomFieldSubQueryUsingContext(CreateDefaultContext());
-        [Test] public void List() => GenericTests.List(CreateDefaultContext());
-        [Test] public void ListTypeIsList() => GenericTests.ListTypeIsList(CreateDefaultContext());
-        [Test] public void NestedEntityList() => GenericTests.NestedEntityList(CreateDefaultContext());
-        [Test] public void PostField() => GenericTests.PostField(CreateDefaultContext());
-        [Test] public void PostFieldSubQuery() => GenericTests.PostFieldSubQuery(CreateDefaultContext());
-        [Test] public void TypeName() => GenericTests.TypeName(CreateDefaultContext());
-        [Test] public void DateTimeFilter() => GenericTests.DateTimeFilter(CreateDefaultContext());
-        [Test] public void EnumerableSubField() => GenericTests.EnumerableSubField(CreateDefaultContext());
-        [Test] public void SimpleMutation() => GenericTests.SimpleMutation(CreateDefaultContext());
-        [Test] public void MutationWithReturn() => GenericTests.MutationWithReturn(CreateDefaultContext());
-        [Test] public void NullPropagation() => GenericTests.NullPropagation(CreateDefaultContext());
-        [Test] public void GuidField() => GenericTests.GuidField(CreateDefaultContext());
-        [Test] public void GuidParameter() => GenericTests.GuidParameter(CreateDefaultContext());
-        [Test] public void ByteArrayParameter() => GenericTests.ByteArrayParameter(CreateDefaultContext());
-        [Test] public void ChildListFieldWithParameters() => GenericTests.ChildListFieldWithParameters(MemContext.CreateDefaultContext());
-        [Test] public void ChildFieldWithParameters() => GenericTests.ChildFieldWithParameters(MemContext.CreateDefaultContext());
+        private static void InitializeCharacterSchema(GraphQLSchema<EfContext> schema)
+        {
+            var character = schema.AddType<Character>();
+            character.AddField(c => c.Id);
+            character.AddField(c => c.Name);
+
+            //character.AddField("height", c => c is Human? (c as Human).Height : 0);
+            //character.AddField("primaryFunction", c => c is Droid ? (c as Droid).PrimaryFunction : null);
+
+            var human = character.IncludeType<Human>();
+            human.AddField(c => c.Id);
+            human.AddField(c => c.Name);
+            human.AddField(h => h.Height);
+
+            var droid = character.IncludeType<Droid>();
+            droid.AddField(c => c.Id);
+            droid.AddField(c => c.Name);
+            droid.AddField(h => h.PrimaryFunction);
+
+            schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.SingleOrDefault(h => h.Id == args.id));
+            schema.AddListField("heros", db => db.Heros);
+        }
+
+        [Test]
+        public void LookupSingleEntity() => GenericTests.LookupSingleEntity(CreateDefaultContext());
+        [Test]
+        public void AliasOneField() => GenericTests.AliasOneField(CreateDefaultContext());
+        [Test]
+        public void NestedEntity() => GenericTests.NestedEntity(CreateDefaultContext());
+        [Test]
+        public void NoUserQueryReturnsNull() => GenericTests.NoUserQueryReturnsNull(CreateDefaultContext());
+        [Test]
+        public void CustomFieldSubQuery() => GenericTests.CustomFieldSubQuery(CreateDefaultContext());
+        [Test]
+        public void CustomFieldSubQueryUsingContext() => GenericTests.CustomFieldSubQueryUsingContext(CreateDefaultContext());
+        [Test]
+        public void List() => GenericTests.List(CreateDefaultContext());
+        [Test]
+        public void ListTypeIsList() => GenericTests.ListTypeIsList(CreateDefaultContext());
+        [Test]
+        public void NestedEntityList() => GenericTests.NestedEntityList(CreateDefaultContext());
+        [Test]
+        public void PostField() => GenericTests.PostField(CreateDefaultContext());
+        [Test]
+        public void PostFieldSubQuery() => GenericTests.PostFieldSubQuery(CreateDefaultContext());
+        [Test]
+        public void TypeName() => GenericTests.TypeName(CreateDefaultContext());
+        [Test]
+        public void DateTimeFilter() => GenericTests.DateTimeFilter(CreateDefaultContext());
+        [Test]
+        public void EnumerableSubField() => GenericTests.EnumerableSubField(CreateDefaultContext());
+        [Test]
+        public void SimpleMutation() => GenericTests.SimpleMutation(CreateDefaultContext());
+        [Test]
+        public void MutationWithReturn() => GenericTests.MutationWithReturn(CreateDefaultContext());
+        [Test]
+        public void NullPropagation() => GenericTests.NullPropagation(CreateDefaultContext());
+        [Test]
+        public void GuidField() => GenericTests.GuidField(CreateDefaultContext());
+        [Test]
+        public void GuidParameter() => GenericTests.GuidParameter(CreateDefaultContext());
+        [Test]
+        public void ByteArrayParameter() => GenericTests.ByteArrayParameter(CreateDefaultContext());
+        [Test]
+        public void ChildListFieldWithParameters() => GenericTests.ChildListFieldWithParameters(MemContext.CreateDefaultContext());
+        [Test]
+        public void ChildFieldWithParameters() => GenericTests.ChildFieldWithParameters(MemContext.CreateDefaultContext());
 
         [Test]
         public void AddAllFields()
@@ -170,6 +234,30 @@ namespace Tests.EF
             var gql = new GraphQL<EfContext>(schema);
             var results = gql.ExecuteQuery("{ user(id:1) { id, name } }");
             Test.DeepEquals(results, "{ user: { id: 1, name: 'Joe User' } }");
+        }
+
+        [Test]
+        public void QueryInlineFragements()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            InitializeCharacterSchema(schema);
+            schema.Complete();
+
+            var gql = new GraphQL<EfContext>(schema);
+            var results = gql.ExecuteQuery("{ heros { name, __typename, ... on Human { height }, ... on Droid { primaryFunction } } }");
+            Test.DeepEquals(results, "{ heros: [ { name: 'Han Solo', __typename: 'Human',  height: 5.6430448}, { name: 'R2-D2', __typename: 'Droid', primaryFunction: 'Astromech' } ] }");
+        }
+
+        [Test]
+        public void QueryInlineFragements2()
+        {
+            var schema = GraphQL<EfContext>.CreateDefaultSchema(() => new EfContext());
+            InitializeCharacterSchema(schema);
+            schema.Complete();
+
+            var gql = new GraphQL<EfContext>(schema);
+            var results = gql.ExecuteQuery("{ heros { name, __typename, ...human, ...droid } }, fragment human on Human { height }, fragment droid on Droid { primaryFunction }");
+            Test.DeepEquals(results, "{ heros: [ { name: 'Han Solo', __typename: 'Human',  height: 5.6430448}, { name: 'R2-D2', __typename: 'Droid', primaryFunction: 'Astromech' } ] }");
         }
 
         class Sub
@@ -197,6 +285,7 @@ namespace Tests.EF
             public IDbSet<Account> Accounts { get; set; }
             public IDbSet<MutateMe> MutateMes { get; set; }
             public IDbSet<NullRef> NullRefs { get; set; }
+            public IDbSet<Character> Heros { get; set; }
         }
 
         class User
@@ -219,7 +308,7 @@ namespace Tests.EF
             public bool Paid { get; set; }
             public DateTime? PaidUtc { get; set; }
             public Guid SomeGuid { get; set; }
-            public byte[] ByteArray { get; set; } = {1, 2, 3, 4};
+            public byte[] ByteArray { get; set; } = { 1, 2, 3, 4 };
 
             public List<User> Users { get; set; }
         }
@@ -233,6 +322,22 @@ namespace Tests.EF
         class NullRef
         {
             public int Id { get; set; }
+        }
+
+        class Character
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        class Human : Character
+        {
+            public double Height { get; set; }
+        }
+
+        class Droid : Character
+        {
+            public string PrimaryFunction { get; set; }
         }
     }
 }

--- a/Tests/InMemoryExecutionTests.cs
+++ b/Tests/InMemoryExecutionTests.cs
@@ -31,6 +31,11 @@ namespace Tests
         [Test] public void ByteArrayParameter() => GenericTests.ByteArrayParameter(MemContext.CreateDefaultContext());
         [Test] public void ChildListFieldWithParameters() => GenericTests.ChildListFieldWithParameters(MemContext.CreateDefaultContext());
         [Test] public void ChildFieldWithParameters() => GenericTests.ChildFieldWithParameters(MemContext.CreateDefaultContext());
+        [Test] public static void Fragements() => GenericTests.Fragements(MemContext.CreateDefaultContext());
+        [Test] public static void InlineFragements() => GenericTests.InlineFragements(MemContext.CreateDefaultContext());
+        [Test] public static void FragementWithMultiLevelInheritance() => GenericTests.FragementWithMultiLevelInheritance(MemContext.CreateDefaultContext());
+        [Test] public static void InlineFragementWithoutTypenameField() => GenericTests.InlineFragementWithoutTypenameField(MemContext.CreateDefaultContext());
+        [Test] public static void FragementWithoutTypenameField() => GenericTests.FragementWithoutTypenameField(MemContext.CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests/MemContext.cs
+++ b/Tests/MemContext.cs
@@ -48,12 +48,36 @@ namespace Tests
                 Value = 0,
             });
             account2.Users = new List<User> { user2 };
+            
+            var human = new Human
+            {
+                Id = 1,
+                Name = "Han Solo",
+                Height = 5.6430448
+            };
+            Heros.Add(human);
+            var stormtrooper = new Stormtrooper
+            {
+                Id = 2,
+                Name = "FN-2187",
+                Height = 4.9,
+                Specialization = "Imperial Snowtrooper"
+            };
+            Heros.Add(stormtrooper);
+            var droid = new Droid
+            {
+                Id = 3,
+                Name = "R2-D2",
+                PrimaryFunction = "Astromech"
+            };
+            Heros.Add(droid);
         }
 
         public List<User> Users { get; set; } = new List<User>();
         public List<Account> Accounts { get; set; } = new List<Account>();
         public List<MutateMe> MutateMes { get; set; } = new List<MutateMe>();
         public List<NullRef> NullRefs { get; set; } = new List<NullRef>();
+        public List<Character> Heros { get; set; } = new List<Character>();
 
         public static GraphQL<MemContext> CreateDefaultContext()
         {
@@ -70,6 +94,7 @@ namespace Tests
             InitializeAccountSchema(schema);
             InitializeMutationSchema(schema);
             InitializeNullRefSchema(schema);
+            InitializeCharacterSchema(schema);
             return schema;
         }
 
@@ -145,6 +170,25 @@ namespace Tests
             var nullRef = schema.AddType<NullRef>();
             nullRef.AddField(n => n.Id);
         }
+        
+        private static void InitializeCharacterSchema(GraphQLSchema<MemContext> schema)
+        {
+            var character = schema.AddType<Character>();
+            character.AddField(c => c.Id);
+            character.AddField(c => c.Name);
+
+            var human = schema.AddType<Human>();
+            human.AddField(h => h.Height);
+
+            var stormtrooper = schema.AddType<Stormtrooper>();
+            stormtrooper.AddField(h => h.Specialization);
+
+            var droid = schema.AddType<Droid>();
+            droid.AddField(h => h.PrimaryFunction);
+
+            schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.AsQueryable().SingleOrDefault(h => h.Id == args.id));
+            schema.AddListField("heros", db => db.Heros.AsQueryable());
+        }
     }
 
     public class User
@@ -186,5 +230,26 @@ namespace Tests
     public class NullRef
     {
         public int Id { get; set; }
+    }
+
+    public class Character
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Human : Character
+    {
+        public double Height { get; set; }
+    }
+
+    public class Stormtrooper : Human
+    {
+        public string Specialization { get; set; }
+    }
+
+    public class Droid : Character
+    {
+        public string PrimaryFunction { get; set; }
     }
 }


### PR DESCRIPTION
Here a is a simple approach to support type conditions as discussed in https://github.com/ckimes89/graphql-net/issues/54.

There are still some pending issues, but i would like to hear your opinion on this approach before proceeding with the implementation.
This might also be very EF specifc, so i would appreciate any hints to generalize for other queryable backends.

The basic steps are:

- Schema types can have `included types` which represent concrete types for interfaces or inheriting classes for classes. 
This can be done by using the method `GraphQLTypeBuilder.IncludeType()`:
   ```csharp
var character = schema.AddType<Character>();
character.AddField(c => c.Id);
character.AddField(c => c.Name);

var human = character.IncludeType<Human>();
human.AddField(h => (h as Human).Height);

var droid = character.IncludeType<Droid>();
droid.AddField(h => (h as Droid).PrimaryFunction);
```
Theses included types are stored in the property `GraphQLType.IncludedTypes`.

- The parser validates selections in fragments against the type condition of the fragment.
- The `DynamicTypeBuilder` extends the `type` by all properties of it's `IncludedTypes`.
- Special handling of the default field `__typename`:
For types with included types, the field is generated as a field selector with a nested conditional-expression for every included type (using `Expression.TypeIs`) and the 'base type' as the default value.

- The filtering of the result fields is not implemented properly yet.


Some further ideas/remarks:

- The method `GraphQLTypeBuilder.IncludeType()` currently returns a `GraphQLTypeBuilder`, i.e. nested include-types are possible. There should be a class `GraphQlIncludeType` and the method should return a specific builder (`GraphQLIncludeTypeBuilder`) with it's own API to disallow nested include-types.
- The schema definition could be generalized to support different queryable backends. The `is-Type`-Expression as well as the `__typename`-selection-expression  could be passed parametrized.
- The fields of the result have be filtered properly.


What do you think of this approach?