### PR TITLE
Pass TContext per query execution

### DIFF
--- a/GraphQL.Net/Executor.cs
+++ b/GraphQL.Net/Executor.cs
@@ -14,15 +14,6 @@ namespace GraphQL.Net
     internal static class Executor<TContext>
     {
         public static object Execute
-            (GraphQLSchema<TContext> schema, GraphQLField field, ExecSelection<Info> query)
-        {
-            var context = schema.ContextCreator();
-            var results = Execute(schema, context, field, query);
-            (context as IDisposable)?.Dispose();
-            return results;
-        }
-
-        public static object Execute
             (GraphQLSchema<TContext> schema, TContext context, GraphQLField field, ExecSelection<Info> query)
         {
             var mutReturn = field.RunMutation(context, query.Arguments.Values());

--- a/GraphQL.Net/GraphQLSchema.cs
+++ b/GraphQL.Net/GraphQLSchema.cs
@@ -23,11 +23,15 @@ namespace GraphQL.Net
 
         public static readonly ParameterExpression DbParam = Expression.Parameter(typeof(TContext), "db");
 
-        public GraphQLSchema(Func<TContext> contextCreator)
+        public GraphQLSchema()
         {
-            ContextCreator = contextCreator;
             AddType<TContext>("queryType");
             AddDefaultExpressionOptions();
+        }
+
+        public GraphQLSchema(Func<TContext> contextCreator) : this()
+        {
+            ContextCreator = contextCreator;
         }
 
         public void AddEnum<TEnum>(string name = null, string prefix = null) where TEnum : struct // wish we could do where TEnum : Enum


### PR DESCRIPTION
Hi,
i would like to pass the TContext for every query execution instead of using a context-creator function.
This can be convenient, if the context instantiation is managed by a DI-container. 

E.g. in Web API applications the TContext might be passed as a constructor parameter to controllers. In those cases it is not impossible but incovnenient to create the graphql-net schema once and execute a graphql-query per request using the creator-function.

This pull request enables passing the TContext per graphql-query, however, it does not change the API, the context creator function is still there.

Do you think this is generally useful?