### PR TITLE
Fix handling of selections with inline fragments.

### DIFF
--- a/GraphQL.Net/Executor.cs
+++ b/GraphQL.Net/Executor.cs
@@ -238,10 +238,9 @@ namespace GraphQL.Net
                 {
                     graphQlType = graphQlType.BaseType;
                 }
-                if (graphQlType != null)
+                var typeNameField = graphQlType?.OwnFields.Find(f => f.Name == "__typename");
+                if (typeNameField != null && !typeNameField.IsPost)
                 {
-                    var typeNameField = graphQlType.OwnFields.Find(f => f.Name == "__typename");
-
                     var typeNameExecSelection = new ExecSelection<Info>(
                         new SchemaField(
                             schema.Adapter.QueryTypes[graphQlType?.Name],

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -235,6 +235,8 @@ namespace Tests.EF
         public static void InlineFragementWithoutTypenameField() => GenericTests.InlineFragementWithoutTypenameField(CreateDefaultContext());
         [Test]
         public static void FragementWithoutTypenameField() => GenericTests.FragementWithoutTypenameField(CreateDefaultContext());
+        [Test]
+        public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests/GenericTests.cs
+++ b/Tests/GenericTests.cs
@@ -204,9 +204,21 @@ namespace Tests
             Test.DeepEquals(
                 results,
                 "{ heros: [ " +
-                "{ name: 'Han Solo',}, " +
+                "{ name: 'Han Solo'}, " +
                 "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
-                "{ name: 'R2-D2', } ] }"
+                "{ name: 'R2-D2' } ] }"
+                );
+        }
+
+        public static void InlineFragementWithoutTypenameFieldWithoutOtherFields<TContext>(GraphQL<TContext> gql)
+        {
+            var results = gql.ExecuteQuery("{ heros { ... on Stormtrooper { height, specialization } } }");
+            Test.DeepEquals(
+                results,
+                "{ heros: [ " +
+                "{ }, " +
+                "{ height: 4.9, specialization: 'Imperial Snowtrooper'}, " +
+                "{ } ] }"
                 );
         }
 

--- a/Tests/InMemoryExecutionTests.cs
+++ b/Tests/InMemoryExecutionTests.cs
@@ -36,6 +36,7 @@ namespace Tests
         [Test] public static void FragementWithMultiLevelInheritance() => GenericTests.FragementWithMultiLevelInheritance(MemContext.CreateDefaultContext());
         [Test] public static void InlineFragementWithoutTypenameField() => GenericTests.InlineFragementWithoutTypenameField(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithoutTypenameField() => GenericTests.FragementWithoutTypenameField(MemContext.CreateDefaultContext());
+        [Test] public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(MemContext.CreateDefaultContext());
 
         [Test]
         public void AddAllFields()


### PR DESCRIPTION
There is an issue when executing queries with inline fragments and type conditions.
The implementation assumes that the first selection is part of the base type, e.g. the following query succeeds:

```
{ heros { name, ... on Stormtrooper { height, specialization } } }
```

But the following query fails/throws an exception:
```
{ heros { ... on Stormtrooper { height, specialization } } }
```

This patch introduces a unit test for this case and fixes the issue.
