### PR TITLE
Support of Type Unions

### DIFF
--- a/GraphQL.Net/GraphQLSchema.cs
+++ b/GraphQL.Net/GraphQLSchema.cs
@@ -137,6 +137,7 @@ namespace GraphQL.Net
             foreach (var graphQLType in types)
             {
                 RelateTypeWithAncestorTypes(graphQLType, types);
+                RelateTypeWithImplementedInterfaces(graphQLType, types);
             }
         }
 
@@ -155,6 +156,16 @@ namespace GraphQL.Net
 
             ancestorGraphQlType?.IncludedTypes.Add(graphQLType);
             graphQLType.BaseType = ancestorGraphQlType;
+        }
+
+        private static void RelateTypeWithImplementedInterfaces(GraphQLType graphQLType, List<GraphQLType> types)
+        {
+
+            foreach (var interf in graphQLType.CLRType.GetInterfaces())
+            {
+                var graphQlInterfaceType = types.Find(t => t.CLRType == interf);
+                graphQlInterfaceType?.IncludedTypes.Add(graphQLType);
+            }
         }
 
         private static void CompleteTypes(IEnumerable<GraphQLType> types)
@@ -177,7 +188,24 @@ namespace GraphQL.Net
                 return;
             }
 
-            var fields = type.GetQueryFields();
+            var fallFields = type.GetQueryFields();
+
+            // For union types there may duplicate fields. Validate those and remove duplicates
+            var fieldGroupedByName = fallFields.GroupBy(f => f.Name).ToList();
+
+            // All fields with the same name have to be of the same type.
+            foreach (var fieldGroup in fieldGroupedByName)
+            {
+                var typeOfFirstField = fieldGroup.FirstOrDefault()?.Type;
+                if (fieldGroup.Any(f => f.Type != typeOfFirstField))
+                {
+                    var fieldName = fieldGroup.FirstOrDefault()?.Name;
+                    throw new ArgumentException($"The type '{type.Name}' has multiple fields named '{fieldName}' with different types.");
+                }
+            }
+
+            var fields = fieldGroupedByName.Select(g => g.First());
+
             var fieldDict = fields.Where(f => !f.IsPost).ToDictionary(f => f.Name, f => f.Type.IsScalar ? TypeHelpers.MakeNullable(f.Type.CLRType) : typeof(object));
             type.QueryType = DynamicTypeBuilder.CreateDynamicType(type.Name + Guid.NewGuid(), fieldDict);
         }

--- a/GraphQL.Net/GraphQLSchema.cs
+++ b/GraphQL.Net/GraphQLSchema.cs
@@ -160,7 +160,6 @@ namespace GraphQL.Net
 
         private static void RelateTypeWithImplementedInterfaces(GraphQLType graphQLType, List<GraphQLType> types)
         {
-
             foreach (var interf in graphQLType.CLRType.GetInterfaces())
             {
                 var graphQlInterfaceType = types.Find(t => t.CLRType == interf);
@@ -188,16 +187,16 @@ namespace GraphQL.Net
                 return;
             }
 
-            var fallFields = type.GetQueryFields();
+            var allFields = type.GetQueryFields();
 
             // For union types there may duplicate fields. Validate those and remove duplicates
-            var fieldGroupedByName = fallFields.GroupBy(f => f.Name).ToList();
+            var fieldGroupedByName = allFields.GroupBy(f => f.Name).ToList();
 
             // All fields with the same name have to be of the same type.
             foreach (var fieldGroup in fieldGroupedByName)
             {
                 var typeOfFirstField = fieldGroup.FirstOrDefault()?.Type;
-                if (fieldGroup.Any(f => f.Type != typeOfFirstField))
+                if (fieldGroup.Any(f => f.Type?.CLRType?.IsAssignableFrom(typeOfFirstField?.CLRType) == false && typeOfFirstField?.CLRType?.IsAssignableFrom(f.Type?.CLRType) == false))
                 {
                     var fieldName = fieldGroup.FirstOrDefault()?.Name;
                     throw new ArgumentException($"The type '{type.Name}' has multiple fields named '{fieldName}' with different types.");

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -164,18 +164,10 @@ namespace Tests.EF
 
         private static void InitializeCharacterSchema(GraphQLSchema<EfContext> schema)
         {
-            var character = schema.AddType<Character>();
-            character.AddField(c => c.Id);
-            character.AddField(c => c.Name);
-
-            var human = schema.AddType<Human>();
-            human.AddField(h => h.Height);
-
-            var stormtrooper = schema.AddType<Stormtrooper>();
-            stormtrooper.AddField(h => h.Specialization);
-
-            var droid = schema.AddType<Droid>();
-            droid.AddField(h => h.PrimaryFunction);
+            schema.AddType<Character>().AddAllFields();
+            schema.AddType<Human>().AddAllFields();
+            schema.AddType<Stormtrooper>().AddAllFields();
+            schema.AddType<Droid>().AddAllFields();
 
             schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.SingleOrDefault(h => h.Id == args.id));
             schema.AddListField("heros", db => db.Heros);
@@ -239,6 +231,8 @@ namespace Tests.EF
         public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(CreateDefaultContext());
         [Test]
         public static void FragementWithMultipleTypenameFields() => GenericTests.FragementWithMultipleTypenameFields(CreateDefaultContext());
+        [Test]
+        public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment() => GenericTests.FragementWithMultipleTypenameFieldsMixedWithInlineFragment(CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -237,6 +237,8 @@ namespace Tests.EF
         public static void FragementWithoutTypenameField() => GenericTests.FragementWithoutTypenameField(CreateDefaultContext());
         [Test]
         public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(CreateDefaultContext());
+        [Test]
+        public static void FragementWithMultipleTypenameFields() => GenericTests.FragementWithMultipleTypenameFields(CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests/GenericTests.cs
+++ b/Tests/GenericTests.cs
@@ -234,5 +234,18 @@ namespace Tests
                 "{ name: 'R2-D2', } ] }"
                 );
         }
+
+        public static void FragementWithMultipleTypenameFields<TContext>(GraphQL<TContext> gql)
+        {
+            var results = gql.ExecuteQuery(
+                "{ heros { name, ...stormtrooper, __typename } }, fragment stormtrooper on Stormtrooper { height, specialization, __typename } ");
+            Test.DeepEquals(
+                results,
+                "{ heros: [ " +
+                "{ name: 'Han Solo', __typename: 'Human'}, " +
+                "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper', __typename: 'Stormtrooper'}, " +
+                "{ name: 'R2-D2', __typename: 'Droid'} ] }"
+                );
+        }
     }
 }

--- a/Tests/GenericTests.cs
+++ b/Tests/GenericTests.cs
@@ -247,5 +247,18 @@ namespace Tests
                 "{ name: 'R2-D2', __typename: 'Droid'} ] }"
                 );
         }
+
+        public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment<TContext>(GraphQL<TContext> gql)
+        {
+            var results = gql.ExecuteQuery(
+                "{ heros { ...stormtrooper, __typename, ... on Human {name}, ... on Droid {name}}}, fragment stormtrooper on Stormtrooper { name, height, specialization, __typename } ");
+            Test.DeepEquals(
+                results,
+                "{ heros: [ " +
+                "{ __typename: 'Human',  name: 'Han Solo'}, " +
+                "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper', __typename: 'Stormtrooper'}, " +
+                "{ __typename: 'Droid', name: 'R2-D2'} ] }"
+                );
+        }
     }
 }

--- a/Tests/InMemoryExecutionTests.cs
+++ b/Tests/InMemoryExecutionTests.cs
@@ -37,6 +37,7 @@ namespace Tests
         [Test] public static void InlineFragementWithoutTypenameField() => GenericTests.InlineFragementWithoutTypenameField(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithoutTypenameField() => GenericTests.FragementWithoutTypenameField(MemContext.CreateDefaultContext());
         [Test] public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(MemContext.CreateDefaultContext());
+        [Test] public static void FragementWithMultipleTypenameFields() => GenericTests.FragementWithMultipleTypenameFields(MemContext.CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests/InMemoryExecutionTests.cs
+++ b/Tests/InMemoryExecutionTests.cs
@@ -38,6 +38,7 @@ namespace Tests
         [Test] public static void FragementWithoutTypenameField() => GenericTests.FragementWithoutTypenameField(MemContext.CreateDefaultContext());
         [Test] public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithMultipleTypenameFields() => GenericTests.FragementWithMultipleTypenameFields(MemContext.CreateDefaultContext());
+        [Test] public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment() => GenericTests.FragementWithMultipleTypenameFieldsMixedWithInlineFragment(MemContext.CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests/MemContext.cs
+++ b/Tests/MemContext.cs
@@ -173,18 +173,10 @@ namespace Tests
         
         private static void InitializeCharacterSchema(GraphQLSchema<MemContext> schema)
         {
-            var character = schema.AddType<Character>();
-            character.AddField(c => c.Id);
-            character.AddField(c => c.Name);
-
-            var human = schema.AddType<Human>();
-            human.AddField(h => h.Height);
-
-            var stormtrooper = schema.AddType<Stormtrooper>();
-            stormtrooper.AddField(h => h.Specialization);
-
-            var droid = schema.AddType<Droid>();
-            droid.AddField(h => h.PrimaryFunction);
+            schema.AddType<Character>().AddAllFields();
+            schema.AddType<Human>().AddAllFields();
+            schema.AddType<Stormtrooper>().AddAllFields();
+            schema.AddType<Droid>().AddAllFields();
 
             schema.AddField("hero", new { id = 0 }, (db, args) => db.Heros.AsQueryable().SingleOrDefault(h => h.Id == args.id));
             schema.AddListField("heros", db => db.Heros.AsQueryable());


### PR DESCRIPTION
Hi, 
i faced some issues with type unions and fragments with type conditions.

Queries where the same field selector is present in multiple fragments are not support yet, e.g:
```
query { 
   heros {
      ...stormtrooper, 
      __typename, 
      ... on Human { name },
      ... on Droid { name }
   }
},
fragment stormtrooper on Stormtrooper { 
   name, 
   height, 
   specialization, 
   __typename 
}
```

This pull request introduces unit tests for such cases and fixes the issue.

Additionally, these changes improve the schema defintion for types with inheritance.
The current implementation does not allow sub-types to add a field which is already defined by it's base type. In the following example, the base type `Character` defines the fields `id` and `name`.
For the types `Human` and `Stormtrooper` only additional fields shouldbe added:
```csharp
var character = schema.AddType<Character>();
AddField(c => c.Id);
AddField(c => c.Name);

human = schema.AddType<Human>();
AddField(h => h.Height);

stormtrooper = schema.AddType<Stormtrooper>();
AddField(h => h.Specialization);

droid = schema.AddType<Droid>();
AddField(h => h.PrimaryFunction);
```

This implies that the method `AddAllFields` can not be invoked for any type with a base type included in the schema as well asother drawbacks.

The changes of this PR allow schema defintions as follows:
```csharp
schema.AddType<Character>().AddAllFields();
AddType<Human>().AddAllFields();
AddType<Stormtrooper>().AddAllFields();
AddType<Droid>().AddAllFields();
```


Please let me know what you think about the changes :)