### PR TITLE
Mutation execution parameters

### DIFF
--- a/GraphQL.Net/GraphQL.cs
+++ b/GraphQL.Net/GraphQL.cs
@@ -15,7 +15,7 @@ namespace GraphQL.Net
             _schema = schema;
         }
 
-        public IDictionary<string, object> ExecuteQuery(string queryStr, TExecutionParameters executionParameters)
+        public IDictionary<string, object> ExecuteQuery(string queryStr, TExecutionParameters executionParameters = default(TExecutionParameters))
         {
             if (_schema.ContextCreator == null)
                 throw new InvalidOperationException("No context creator specified. Either pass a context " +
@@ -59,16 +59,6 @@ namespace GraphQL.Net
         public static GraphQLSchema<TContext> CreateDefaultSchema(Func<TContext> creationFunc)
         {
             return Schema = new GraphQLSchema<TContext>(creationFunc);
-        }
-
-        public IDictionary<string, object> ExecuteQuery(string queryStr)
-        {
-            return ExecuteQuery(queryStr, new NoExecutionParameters());
-        }
-
-        public IDictionary<string, object> ExecuteQuery(string queryStr, TContext queryContext)
-        {
-            return ExecuteQuery(queryStr, queryContext, new NoExecutionParameters());
         }
     }
 

--- a/GraphQL.Net/GraphQL.cs
+++ b/GraphQL.Net/GraphQL.cs
@@ -1,53 +1,39 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using GraphQL.Net.SchemaAdapters;
+﻿using GraphQL.Net.SchemaAdapters;
 using GraphQL.Parser;
 using GraphQL.Parser.Execution;
-using Microsoft.FSharp.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GraphQL.Net
 {
-    public class GraphQL<TContext>
+    public class GraphQL<TContext, TExecutionParameters>
     {
-        public static GraphQLSchema<TContext> Schema;
-
-        private readonly GraphQLSchema<TContext> _schema;
-        public GraphQL(GraphQLSchema<TContext> schema = null)
+        private readonly GraphQLSchema<TContext, TExecutionParameters> _schema;
+        public GraphQL(GraphQLSchema<TContext, TExecutionParameters> schema)
         {
-            _schema = schema ?? Schema;
+            _schema = schema;
         }
 
-        public static GraphQLSchema<TContext> CreateDefaultSchema(Func<TContext> creationFunc)
-        {
-            return Schema = new GraphQLSchema<TContext>(creationFunc);
-        }
-
-        public static IDictionary<string, object> Execute(string query)
-        {
-            var gql = new GraphQL<TContext>();
-            return gql.ExecuteQuery(query);
-        }
-
-        public IDictionary<string, object> ExecuteQuery(string queryStr)
+        public IDictionary<string, object> ExecuteQuery(string queryStr, TExecutionParameters executionParameters)
         {
             if (_schema.ContextCreator == null)
                 throw new InvalidOperationException("No context creator specified. Either pass a context " +
                     "creator to the schema's constroctur or call overloaded method 'Execut(string query, TContext context)' " +
                     "and pass a context.");
             var context = _schema.ContextCreator();
-            var result = ExecuteQuery(queryStr, context);
+            var result = ExecuteQuery(queryStr, context, executionParameters);
             (context as IDisposable)?.Dispose();
             return result;
         }
 
-        public IDictionary<string, object> ExecuteQuery(string queryStr, TContext queryContext)
+        public IDictionary<string, object> ExecuteQuery(string queryStr, TContext queryContext, TExecutionParameters execParams)
         {
             if (!_schema.Completed)
                 throw new InvalidOperationException("Schema must be Completed before executing a query. Try calling the schema's Complete method.");
 
             if (queryContext == null)
-                throw new ArgumentException("Contexst must not be null.");
+                throw new ArgumentException("Context must not be null.");
 
             var document = GraphQLDocument<Info>.Parse(_schema.Adapter, queryStr);
             var context = DefaultExecContext.Instance; // TODO use a real IExecContext to support passing variables
@@ -58,9 +44,33 @@ namespace GraphQL.Net
             foreach (var execSelection in execSelections.Select(s => s.Value))
             {
                 var field = execSelection.SchemaField.Field();
-                outputs[execSelection.Name] = Executor<TContext>.Execute(_schema, queryContext, field, execSelection);
+                outputs[execSelection.Name] = Executor<TContext, TExecutionParameters>.Execute(_schema, queryContext, field, execSelection, execParams);
             }
             return outputs;
         }
     }
+
+    public class GraphQL<TContext> : GraphQL<TContext, NoExecutionParameters>
+    {
+        public static GraphQLSchema<TContext> Schema;
+
+        public GraphQL(GraphQLSchema<TContext> schema = null) : base(schema ?? Schema) { }
+
+        public static GraphQLSchema<TContext> CreateDefaultSchema(Func<TContext> creationFunc)
+        {
+            return Schema = new GraphQLSchema<TContext>(creationFunc);
+        }
+
+        public IDictionary<string, object> ExecuteQuery(string queryStr)
+        {
+            return ExecuteQuery(queryStr, new NoExecutionParameters());
+        }
+
+        public IDictionary<string, object> ExecuteQuery(string queryStr, TContext queryContext)
+        {
+            return ExecuteQuery(queryStr, queryContext, new NoExecutionParameters());
+        }
+    }
+
+    public class NoExecutionParameters { }
 }

--- a/GraphQL.Net/GraphQLField.cs
+++ b/GraphQL.Net/GraphQLField.cs
@@ -43,8 +43,8 @@ namespace GraphQL.Net
             ? (LambdaExpression)ExprFunc.DynamicInvoke(TypeHelpers.GetArgs(ArgsCLRType, Schema.VariableTypes, inputs), mutationReturn)
             : (LambdaExpression)ExprFunc.DynamicInvoke(TypeHelpers.GetArgs(ArgsCLRType, Schema.VariableTypes, inputs));
 
-        public virtual object RunMutation<TContext>(TContext context, IEnumerable<ExecArgument<Info>> inputs)
-            => MutationFunc?.DynamicInvoke(context, TypeHelpers.GetArgs(ArgsCLRType, Schema.VariableTypes, inputs));
+        public virtual object RunMutation<TContext, TExecutionParameters>(TContext context, IEnumerable<ExecArgument<Info>> inputs, TExecutionParameters executionParameters)
+            => MutationFunc?.DynamicInvoke(context, TypeHelpers.GetArgs(ArgsCLRType, Schema.VariableTypes, inputs), executionParameters);
 
         public Complexity Complexity { get; set; }
 
@@ -63,11 +63,14 @@ namespace GraphQL.Net
                 PostFieldFunc = () => fieldFunc(),
             };
         }
-
+        
         public static GraphQLField New<TArgs>(GraphQLSchema schema, string name, Func<TArgs, LambdaExpression> exprFunc, Type fieldCLRType, GraphQLType definingType)
             => NewInternal<TArgs>(schema, name, exprFunc, fieldCLRType, definingType, null);
 
-        public static GraphQLField NewMutation<TContext, TArgs, TMutReturn>(GraphQLSchema schema, string name, Func<TArgs, TMutReturn, LambdaExpression> exprFunc, Type fieldCLRType, GraphQLType definingType, Func<TContext, TArgs, TMutReturn> mutationFunc)
+        public static GraphQLField New<TArgs, TExecutionParameters>(GraphQLSchema schema, string name, Func<TArgs, TExecutionParameters, LambdaExpression> exprFunc, Type fieldCLRType, GraphQLType definingType)
+            => NewInternal<TArgs>(schema, name, exprFunc, fieldCLRType, definingType, null);
+
+        public static GraphQLField NewMutation<TContext, TArgs, TExecutionParameters, TMutReturn>(GraphQLSchema schema, string name, Func<TArgs, TMutReturn, LambdaExpression> exprFunc, Type fieldCLRType, GraphQLType definingType, Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutationFunc)
             => NewInternal<TArgs>(schema, name, exprFunc, fieldCLRType, definingType, mutationFunc);
 
         private static GraphQLField NewInternal<TArgs>(GraphQLSchema schema, string name, Delegate exprFunc, Type fieldCLRType, GraphQLType definingType, Delegate mutationFunc)

--- a/GraphQL.Net/GraphQLFieldBuilder.cs
+++ b/GraphQL.Net/GraphQLFieldBuilder.cs
@@ -3,7 +3,7 @@ using GraphQL.Parser;
 
 namespace GraphQL.Net
 {
-    public class GraphQLFieldBuilder<TContext, TField>
+    public class GraphQLFieldBuilder<TContext, TExecutionParameters, TField>
     {
         private readonly GraphQLField _field;
 
@@ -12,20 +12,20 @@ namespace GraphQL.Net
             _field = field;
         }
 
-        public GraphQLFieldBuilder<TContext, TField> WithDescription(string description)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> WithDescription(string description)
         {
             _field.Description = description;
             return this;
         }
 
-        public GraphQLFieldBuilder<TContext, TField> WithComplexity(long min, long max)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> WithComplexity(long min, long max)
         {
             _field.Complexity = Complexity.NewRange(Tuple.Create(min, max));
             return this;
         }
 
         // TODO: This should be removed once we figure out a better way to do it
-        internal GraphQLFieldBuilder<TContext, TField> WithResolutionType(ResolutionType type)
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> WithResolutionType(ResolutionType type)
         {
             _field.ResolutionType = type;
             return this;

--- a/GraphQL.Net/GraphQLTypeBuilder.cs
+++ b/GraphQL.Net/GraphQLTypeBuilder.cs
@@ -6,12 +6,12 @@ using System.Reflection;
 
 namespace GraphQL.Net
 {
-    public class GraphQLTypeBuilder<TContext, TEntity>
+    public class GraphQLTypeBuilder<TContext, TExecutionParameters, TEntity>
     {
-        private readonly GraphQLSchema<TContext> _schema;
+        private readonly GraphQLSchema<TContext, TExecutionParameters> _schema;
         private readonly GraphQLType _type;
 
-        internal GraphQLTypeBuilder(GraphQLSchema<TContext> schema, GraphQLType type)
+        internal GraphQLTypeBuilder(GraphQLSchema<TContext, TExecutionParameters> schema, GraphQLType type)
         {
             _schema = schema;
             _type = type;
@@ -19,19 +19,21 @@ namespace GraphQL.Net
 
         // This overload is provided to the user so they can shape TArgs with an anonymous type and rely on type inference for type parameters
         // e.g.  AddField("profilePic", new { size = 0 }, (db, user) => db.ProfilePics.Where(p => p.UserId == u.Id && p.Size == args.size));
-        [Obsolete]
-        public GraphQLFieldBuilder<TContext, TField> AddField<TArgs, TField>(string name, TArgs shape, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
-            => AddField(name, exprFunc);
-
-        [Obsolete]
-        public GraphQLFieldBuilder<TContext, TField> AddListField<TArgs, TField>(string name, TArgs shape, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
-            => AddListField(name, exprFunc);
-
-        public GraphQLFieldBuilder<TContext, TField> AddField<TArgs, TField>(string name, TArgs shape, Expression<Func<TContext, TArgs, TEntity, TField>> exprFunc)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddField<TArgs, TField>(string name, TArgs shape, Expression<Func<TContext, TArgs, TEntity, TField>> exprFunc)
             => AddFieldInternal(name, AdjustExprFunc(exprFunc));
 
-        public GraphQLFieldBuilder<TContext, TField> AddListField<TArgs, TField>(string name, TArgs shape, Expression<Func<TContext, TArgs, TEntity, IEnumerable<TField>>> exprFunc)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListField<TArgs, TField>(string name, TArgs shape, Expression<Func<TContext, TArgs, TEntity, IEnumerable<TField>>> exprFunc)
             => AddListFieldInternal(name, AdjustExprFunc(exprFunc));
+
+        public Func<TArgs, TExecutionParameters, Expression<Func<TContext, TEntity, TExecutionParameters, TReturn>>> AdjustExprFunc<TArgs, TReturn>(Expression<Func<TContext, TArgs, TEntity, TExecutionParameters, TReturn>> exprFunc)
+        {
+            var param1 = exprFunc.Parameters[1];
+            var param2 = exprFunc.Parameters[2];
+            var transformedExpr = Expression.Lambda(Expression.Convert(exprFunc.Body, typeof(TReturn)), exprFunc.Parameters[0], exprFunc.Parameters[2]);
+            var quoted = Expression.Quote(transformedExpr);
+            var final = Expression.Lambda<Func<TArgs, TExecutionParameters, Expression<Func<TContext, TEntity, TExecutionParameters, TReturn>>>>(quoted, new List<ParameterExpression> { param1, param2});
+            return final.Compile();
+        }
 
         public Func<TArgs, Expression<Func<TContext, TEntity, TReturn>>> AdjustExprFunc<TArgs, TReturn>(Expression<Func<TContext, TArgs, TEntity, TReturn>> exprFunc)
         {
@@ -45,82 +47,104 @@ namespace GraphQL.Net
         // See GraphQLSchema.AddField for an explanation of the type of exprFunc, since it follows similar reasons
         // TL:DR; OwnFields can have parameters passed in, so the Expression<Func> to be used is dependent on TArgs
         //        OwnFields can use TContext as well, so we have to return an Expression<Func<TContext, TEntity, TField>> and replace the TContext parameter when needed
-        public GraphQLFieldBuilder<TContext, TField> AddField<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddField<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
+            => AddFieldInternal(name, exprFunc);
+        
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddField<TArgs, TField>(string name, Func<TArgs, TExecutionParameters, Expression<Func<TContext, TEntity, TExecutionParameters, TField>>> exprFunc)
             => AddFieldInternal(name, exprFunc);
 
-        public GraphQLFieldBuilder<TContext, TField> AddListField<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListField<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
+            => AddListFieldInternal(name, exprFunc);
+
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListField<TArgs, TField>(string name, Func<TArgs, TExecutionParameters, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
             => AddListFieldInternal(name, exprFunc);
 
         // Mutation should be null UNLESS adding a mutation at the schema level
-        internal GraphQLFieldBuilder<TContext, TField> AddFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddFieldInternal<TArgs, TField>(string name, Func<TArgs, TExecutionParameters, Expression<Func<TContext, TEntity, TExecutionParameters, TField>>> exprFunc)
         {
             var field = GraphQLField.New(_schema, name, exprFunc, typeof (TField), _type);
             _type.OwnFields.Add(field);
-            return new GraphQLFieldBuilder<TContext, TField>(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
         }
 
         // Mutation should be null UNLESS adding a mutation at the schema level
-        internal GraphQLFieldBuilder<TContext, TField> AddListFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, TField>>> exprFunc)
+        {
+            var field = GraphQLField.New(_schema, name, exprFunc, typeof(TField), _type);
+            _type.OwnFields.Add(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
+        }
+
+        // Mutation should be null UNLESS adding a mutation at the schema level
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListFieldInternal<TArgs, TField>(string name, Func<TArgs, TExecutionParameters, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
         {
             var field = GraphQLField.New(_schema, name, exprFunc, typeof (IEnumerable<TField>), _type);
             _type.OwnFields.Add(field);
-            return new GraphQLFieldBuilder<TContext, TField>(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
         }
 
         // Mutation should be null UNLESS adding a mutation at the schema level
-        internal GraphQLFieldBuilder<TContext, TField> AddMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, TField>>> exprFunc, Func<TContext, TArgs, TMutReturn> mutation)
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListFieldInternal<TArgs, TField>(string name, Func<TArgs, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc)
+        {
+            var field = GraphQLField.New(_schema, name, exprFunc, typeof(IEnumerable<TField>), _type);
+            _type.OwnFields.Add(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
+        }
+
+        // Mutation should be null UNLESS adding a mutation at the schema level
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, TField>>> exprFunc, Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutation)
         {
             var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (TField), _type, mutation);
             _type.OwnFields.Add(field);
-            return new GraphQLFieldBuilder<TContext, TField>(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
         }
 
         // Mutation should be null UNLESS adding a mutation at the schema level
-        internal GraphQLFieldBuilder<TContext, TField> AddListMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc, Func<TContext, TArgs, TMutReturn> mutation)
+        internal GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListMutationInternal<TArgs, TField, TMutReturn>(string name, Func<TArgs, TMutReturn, Expression<Func<TContext, TEntity, IEnumerable<TField>>>> exprFunc, Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutation)
         {
             var field = GraphQLField.NewMutation(_schema, name, exprFunc, typeof (IEnumerable<TField>), _type, mutation);
             _type.OwnFields.Add(field);
-            return new GraphQLFieldBuilder<TContext, TField>(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
         }
 
-        public GraphQLFieldBuilder<TContext, TField> AddField<TField>(string name, Expression<Func<TEntity, TField>> expr)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddField<TField>(string name, Expression<Func<TEntity, TField>> expr)
         {
-            var lambda = Expression.Lambda<Func<TContext, TEntity, TField>>(expr.Body, GraphQLSchema<TContext>.DbParam, expr.Parameters[0]);
+            var lambda = Expression.Lambda<Func<TContext, TEntity, TField>>(expr.Body, GraphQLSchema<TContext, TExecutionParameters>.DbParam, expr.Parameters[0]);
             return AddField(name.ToCamelCase(), lambda);
         }
 
-        public GraphQLFieldBuilder<TContext, TField> AddListField<TField>(string name, Expression<Func<TEntity, IEnumerable<TField>>> expr)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListField<TField>(string name, Expression<Func<TEntity, IEnumerable<TField>>> expr)
         {
-            var lambda = Expression.Lambda<Func<TContext, TEntity, IEnumerable<TField>>>(expr.Body, GraphQLSchema<TContext>.DbParam, expr.Parameters[0]);
+            var lambda = Expression.Lambda<Func<TContext, TEntity, IEnumerable<TField>>>(expr.Body, GraphQLSchema<TContext, TExecutionParameters>.DbParam, expr.Parameters[0]);
             return AddListField(name.ToCamelCase(), lambda);
         }
 
         // Overload provided for easily adding properties, e.g.  AddField(u => u.Name);
-        public GraphQLFieldBuilder<TContext, TField> AddField<TField>(Expression<Func<TEntity, TField>> expr)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddField<TField>(Expression<Func<TEntity, TField>> expr)
         {
             var member = expr.Body as MemberExpression;
             if (member == null)
                 throw new InvalidOperationException($"Unnamed query {nameof(expr)} must be a MemberExpression of form [p => p.Field].\n\nTry using the explicit AddField overload for a custom field.");
             var name = member.Member.Name;
-            var lambda = Expression.Lambda<Func<TContext, TEntity, TField>>(member, GraphQLSchema<TContext>.DbParam, expr.Parameters[0]);
+            var lambda = Expression.Lambda<Func<TContext, TEntity, TField>>(member, GraphQLSchema<TContext, TExecutionParameters>.DbParam, expr.Parameters[0]);
             return AddField(name.ToCamelCase(), lambda);
         }
 
-        public GraphQLFieldBuilder<TContext, TField> AddListField<TField>(Expression<Func<TEntity, IEnumerable<TField>>> expr)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListField<TField>(Expression<Func<TEntity, IEnumerable<TField>>> expr)
         {
             var member = expr.Body as MemberExpression;
             if (member == null)
                 throw new InvalidOperationException($"Unnamed query {nameof(expr)} must be a MemberExpression of form [p => p.Field].\n\nTry using the explicit AddField overload for a custom field.");
             var name = member.Member.Name;
-            var lambda = Expression.Lambda<Func<TContext, TEntity, IEnumerable<TField>>>(member, GraphQLSchema<TContext>.DbParam, expr.Parameters[0]);
+            var lambda = Expression.Lambda<Func<TContext, TEntity, IEnumerable<TField>>>(member, GraphQLSchema<TContext, TExecutionParameters>.DbParam, expr.Parameters[0]);
             return AddListField(name.ToCamelCase(), lambda);
         }
 
         // Overload provided for adding fields with no arguments, e.g.  AddField("totalCount", (db, u) => db.Users.Count());
-        public GraphQLFieldBuilder<TContext, TField> AddField<TField>(string name, Expression<Func<TContext, TEntity, TField>> expr)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddField<TField>(string name, Expression<Func<TContext, TEntity, TField>> expr)
             => AddField<object, TField>(name, o => expr);
 
-        public GraphQLFieldBuilder<TContext, TField> AddListField<TField>(string name, Expression<Func<TContext, TEntity, IEnumerable<TField>>> expr)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddListField<TField>(string name, Expression<Func<TContext, TEntity, IEnumerable<TField>>> expr)
             => AddListField<object, TField>(name, o => expr);
 
         public void AddAllFields()
@@ -135,7 +159,7 @@ namespace GraphQL.Net
             // build selector expression, e.g.: (db, p) => p.Id
             var entityParam = Expression.Parameter(typeof(TEntity), "p");
             var memberExpr = Expression.MakeMemberAccess(entityParam, prop);
-            var lambda = Expression.Lambda(memberExpr, GraphQLSchema<TContext>.DbParam, entityParam);
+            var lambda = Expression.Lambda(memberExpr, GraphQLSchema<TContext, TExecutionParameters>.DbParam, entityParam);
 
             // build args func wrapping selector expression, e.g. o => (db, p) => p.Id
             var objectParam = Expression.Parameter(typeof(object), "o");
@@ -145,11 +169,11 @@ namespace GraphQL.Net
             return GraphQLField.New(_schema, prop.Name.ToCamelCase(), (Func<object, LambdaExpression>) exprFunc, prop.PropertyType, _type);
         }
 
-        public GraphQLFieldBuilder<TContext, TField> AddPostField<TField>(string name, Func<TField> fieldFunc)
+        public GraphQLFieldBuilder<TContext, TExecutionParameters, TField> AddPostField<TField>(string name, Func<TField> fieldFunc)
         {
             var field = GraphQLField.Post(_schema, name, fieldFunc);
             _type.OwnFields.Add(field);
-            return new GraphQLFieldBuilder<TContext, TField>(field);
+            return new GraphQLFieldBuilder<TContext, TExecutionParameters, TField>(field);
         }
     }
 }

--- a/GraphQL.Net/SchemaAdapters/Schema.cs
+++ b/GraphQL.Net/SchemaAdapters/Schema.cs
@@ -24,12 +24,12 @@ namespace GraphQL.Net.SchemaAdapters
             return _typeMap[type] = new SchemaType(type, this);
         }
     }
-    class Schema<TContext> : Schema
+    class Schema<TContext, TExecutionParameters> : Schema
     {
-        private readonly GraphQLSchema<TContext> _schema;
+        private readonly GraphQLSchema<TContext, TExecutionParameters> _schema;
         private readonly Dictionary<string, ISchemaQueryType<Info>> _queryTypes;
 
-        public Schema(GraphQLSchema<TContext> schema) : base(schema)
+        public Schema(GraphQLSchema<TContext, TExecutionParameters> schema) : base(schema)
         {
             RootType = new SchemaRootType(this, schema.GetGQLType(typeof(TContext)));
             _schema = schema;

--- a/GraphQL.Net/SchemaExtensions.cs
+++ b/GraphQL.Net/SchemaExtensions.cs
@@ -10,104 +10,268 @@ namespace GraphQL.Net
     {
         // This overload is provided to the user so they can shape TArgs with an anonymous type and rely on type inference for type parameters
         // e.g.  AddField("user", new { id = 0 }, (db, args) => db.Users.Where(u => u.Id == args.id));
-        public static GraphQLFieldBuilder<TContext, TEntity> AddField<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddField<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
             => AddField(context, name, queryableGetter);
 
-        public static GraphQLFieldBuilder<TContext, TEntity> AddListField<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListField<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter)
             => AddListField(context, name, queryableGetter);
 
         [Obsolete]
-        public static GraphQLFieldBuilder<TContext, TEntity> AddMutation<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Expression<Func<TContext, TArgs, TEntity>> queryableGetter, Action<TContext, TArgs> mutation)
-            => AddMutation(context, name, argObj, mutation, queryableGetter);
-
-        [Obsolete]
-        public static GraphQLFieldBuilder<TContext, TEntity> AddListMutation<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter, Action<TContext, TArgs> mutation)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListMutation<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter, 
+            Action<TContext, TArgs, TExecutionParameters> mutation)
             => AddListMutation(context, name, argObj, mutation, queryableGetter);
 
-        public static GraphQLFieldBuilder<TContext, TEntity> AddMutation<TContext, TArgs, TEntity, TMutReturn>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Func<TContext, TArgs, TMutReturn> mutation, Expression<Func<TContext, TArgs, TMutReturn, TEntity>> queryableGetter)
+        [Obsolete]
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Expression<Func<TContext, TArgs, TEntity>> queryableGetter, 
+            Action<TContext, TArgs> mutation)
+            => AddMutation(context, name, argObj, mutation, queryableGetter);
+
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters, TMutReturn>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Func<TContext, TArgs, TMutReturn> mutation, 
+            Expression<Func<TContext, TArgs, TMutReturn, TEntity>> queryableGetter)
+            => AddMutation(context, name, queryableGetter, mutation);
+        
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters, TMutReturn>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutation, 
+            Expression<Func<TContext, TArgs, TMutReturn, TEntity>> queryableGetter)
             => AddMutation(context, name, queryableGetter, mutation);
 
-        public static GraphQLFieldBuilder<TContext, TEntity> AddListMutation<TContext, TArgs, TEntity, TMutReturn>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Func<TContext, TArgs, TMutReturn> mutation, Expression<Func<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>> queryableGetter)
-            => AddListMutation(context, name, queryableGetter, mutation);
-
-        public static GraphQLFieldBuilder<TContext, TEntity> AddMutation<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Action<TContext, TArgs> mutation, Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Action<TContext, TArgs> mutation, 
+            Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
         {
-            var transformed = Expression.Lambda<Func<TContext, TArgs, object, TEntity>>(queryableGetter.Body, queryableGetter.Parameters[0], queryableGetter.Parameters[1], Expression.Parameter(typeof(object), "mutRet"));
-            return AddMutation(context, name, transformed, (db, args) => { mutation(db, args); return null; });
+            var transformed = Expression.Lambda<Func<TContext, TArgs, object, TEntity>>(
+                queryableGetter.Body, 
+                queryableGetter.Parameters[0], 
+                queryableGetter.Parameters[1], 
+                Expression.Parameter(typeof(object), "mutRet"));
+            return AddMutation(context, name, transformed, (db, args, execParams) => { mutation(db, args); return null; });
         }
 
-        public static GraphQLFieldBuilder<TContext, TEntity> AddListMutation<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, TArgs argObj, Action<TContext, TArgs> mutation, Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Action<TContext, TArgs, TExecutionParameters> mutation, 
+            Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
         {
-            var transformed = Expression.Lambda<Func<TContext, TArgs, object, IEnumerable<TEntity>>>(queryableGetter.Body, queryableGetter.Parameters[0], queryableGetter.Parameters[1], Expression.Parameter(typeof(object), "mutRet"));
-            return AddListMutation(context, name, transformed, (db, args) => { mutation(db, args); return null; });
+            var transformed = Expression.Lambda<Func<TContext, TArgs, object, TEntity>>(
+                queryableGetter.Body, 
+                queryableGetter.Parameters[0], 
+                queryableGetter.Parameters[1], 
+                Expression.Parameter(typeof(object), "mutRet"));
+            return AddMutation(context, name, transformed, (db, args, execParams) => { mutation(db, args, execParams); return null; });
+        }
+
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListMutation<TContext, TArgs, TEntity, TExecutionParameters, TMutReturn>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutation, 
+            Expression<Func<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>> queryableGetter)
+            => AddListMutation(context, name, queryableGetter, mutation);
+
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListMutation<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            TArgs argObj, 
+            Action<TContext, TArgs, TExecutionParameters> mutation, 
+            Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter)
+        {
+            var transformed = Expression.Lambda<Func<TContext, TArgs, object, IEnumerable<TEntity>>>(
+                queryableGetter.Body, 
+                queryableGetter.Parameters[0], 
+                queryableGetter.Parameters[1], 
+                Expression.Parameter(typeof(object), "mutRet"));
+            return AddListMutation(context, name, transformed, (db, args, execParams) => { mutation(db, args, execParams); return null; });
         }
 
         // Transform  (db, args) => db.Entities.Where(args)  into  args => db => db.Entities.Where(args)
-        private static GraphQLFieldBuilder<TContext, TEntity> AddListField<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter)
+        private static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListField<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, TArgs, IEnumerable<TEntity>>> queryableGetter)
         {
             var innerLambda = Expression.Lambda<Func<TContext, IEnumerable<TEntity>>>(queryableGetter.Body, queryableGetter.Parameters[0]);
             return context.AddFieldInternal(name, GetFinalQueryFunc<TContext, TArgs, IEnumerable<TEntity>>(innerLambda, queryableGetter.Parameters[1]), ResolutionType.ToList);
         }
 
         // Transform  (db, args) => db.Entities.First(args)  into  args => db => db.Entities.First(args)
-        private static GraphQLFieldBuilder<TContext, TEntity> AddField<TContext, TArgs, TEntity>(this GraphQLSchema<TContext> context, string name, Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
+        private static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddField<TContext, TArgs, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, TArgs, TEntity>> queryableGetter)
         {
             var innerLambda = Expression.Lambda<Func<TContext, TEntity>>(queryableGetter.Body, queryableGetter.Parameters[0]);
             var info = GetQueryInfo(innerLambda);
             if (info.ResolutionType != ResolutionType.Unmodified)
-                return context.AddFieldInternal(name, GetFinalQueryFunc<TContext, TArgs, IEnumerable<TEntity>>(info.BaseQuery, queryableGetter.Parameters[1]), info.ResolutionType);
-            return context.AddUnmodifiedFieldInternal(name, GetFinalQueryFunc<TContext, TArgs, TEntity>(info.OriginalQuery, queryableGetter.Parameters[1]));
+                return context.AddFieldInternal(
+                    name, 
+                    GetFinalQueryFunc<TContext, TArgs, IEnumerable<TEntity>>(info.BaseQuery, queryableGetter.Parameters[1]), 
+                    info.ResolutionType);
+            return context.AddUnmodifiedFieldInternal(
+                name, 
+                GetFinalQueryFunc<TContext, TArgs, TEntity>(info.OriginalQuery, queryableGetter.Parameters[1]));
         }
 
         // Transform  (db, args, mut) => db.Entities.Where(args)  into  args => db => db.Entities.Where(args)
-        private static GraphQLFieldBuilder<TContext, TEntity> AddListMutation<TContext, TArgs, TEntity, TMutReturn>(this GraphQLSchema<TContext> context, string name, Expression<Func<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>> queryableGetter, Func<TContext, TArgs, TMutReturn> mutation)
+        private static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListMutation<TContext, TArgs, TEntity, TExecutionParameters, TMutReturn>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>> queryableGetter, 
+            Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutation)
         {
-            var innerLambda = Expression.Lambda<Func<TContext, IEnumerable<TEntity>>>(queryableGetter.Body, queryableGetter.Parameters[0]);
-            return context.AddMutationInternal(name, GetFinalMutationFunc<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>(innerLambda, queryableGetter.Parameters[1], queryableGetter.Parameters[2]), ResolutionType.ToList, mutation);
+            var innerLambda = Expression.Lambda<Func<TContext, IEnumerable<TEntity>>>(
+                queryableGetter.Body, 
+                queryableGetter.Parameters[0]);
+            return context.AddMutationInternal(
+                name, 
+                GetFinalMutationFunc<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>(
+                    innerLambda, 
+                    queryableGetter.Parameters[1], 
+                    queryableGetter.Parameters[2]), 
+                ResolutionType.ToList, mutation);
+        }
+
+        // Transform (db, args) => TMutationResult into (db, args, execParams) => TMutationResult
+        // and (db, args, mut) => db.Entities.First(args)  into  args => db => db.Entities.First(args)
+        private static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters, TMutReturn>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, TArgs, TMutReturn, TEntity>> queryableGetter, 
+            Func<TContext, TArgs, TMutReturn> mutation)
+        {
+            var innerLambda = Expression.Lambda<Func<TContext, TEntity>>(queryableGetter.Body, queryableGetter.Parameters[0]);
+            Func<TContext, TArgs, TExecutionParameters, TMutReturn> transformedMutation = (c, args, execParams) => mutation(c, args);
+            var info = GetQueryInfo(innerLambda);
+            if (info.ResolutionType != ResolutionType.Unmodified)
+                return context.AddMutationInternal(
+                    name, 
+                    GetFinalMutationFunc<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>(
+                        info.BaseQuery, 
+                        queryableGetter.Parameters[1], 
+                        queryableGetter.Parameters[2]), 
+                    info.ResolutionType, 
+                    transformedMutation);
+            return context.AddUnmodifiedMutationInternal(
+                name, 
+                GetFinalMutationFunc<TContext, TArgs, TMutReturn, TEntity>(
+                    info.OriginalQuery, 
+                    queryableGetter.Parameters[1], 
+                    queryableGetter.Parameters[2]), 
+                transformedMutation);
         }
 
         // Transform  (db, args, mut) => db.Entities.First(args)  into  args => db => db.Entities.First(args)
-        private static GraphQLFieldBuilder<TContext, TEntity> AddMutation<TContext, TArgs, TEntity, TMutReturn>(this GraphQLSchema<TContext> context, string name, Expression<Func<TContext, TArgs, TMutReturn, TEntity>> queryableGetter, Func<TContext, TArgs, TMutReturn> mutation)
+        private static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddMutation<TContext, TArgs, TEntity, TExecutionParameters, TMutReturn>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, TArgs, TMutReturn, TEntity>> queryableGetter, 
+            Func<TContext, TArgs, TExecutionParameters, TMutReturn> mutation)
         {
             var innerLambda = Expression.Lambda<Func<TContext, TEntity>>(queryableGetter.Body, queryableGetter.Parameters[0]);
             var info = GetQueryInfo(innerLambda);
             if (info.ResolutionType != ResolutionType.Unmodified)
-                return context.AddMutationInternal(name, GetFinalMutationFunc<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>(info.BaseQuery, queryableGetter.Parameters[1], queryableGetter.Parameters[2]), info.ResolutionType, mutation);
-            return context.AddUnmodifiedMutationInternal(name, GetFinalMutationFunc<TContext, TArgs, TMutReturn, TEntity>(info.OriginalQuery, queryableGetter.Parameters[1], queryableGetter.Parameters[2]), mutation);
+                return context.AddMutationInternal(
+                    name, 
+                    GetFinalMutationFunc<TContext, TArgs, TMutReturn, IEnumerable<TEntity>>(
+                        info.BaseQuery, 
+                        queryableGetter.Parameters[1], 
+                        queryableGetter.Parameters[2]), 
+                    info.ResolutionType, 
+                    mutation);
+            return context.AddUnmodifiedMutationInternal(
+                name, 
+                GetFinalMutationFunc<TContext, TArgs, TMutReturn, TEntity>(
+                    info.OriginalQuery, 
+                    queryableGetter.Parameters[1], 
+                    queryableGetter.Parameters[2]), 
+                mutation);
         }
 
-        private static Func<TArgs, Expression<Func<TContext, TContext, TResult>>> GetFinalQueryFunc<TContext, TArgs, TResult>(Expression<Func<TContext, TResult>> baseExpr, ParameterExpression param = null)
+        private static Func<TArgs, Expression<Func<TContext, TContext, TResult>>> GetFinalQueryFunc<TContext, TArgs, TResult>(
+            Expression<Func<TContext, TResult>> baseExpr, 
+            ParameterExpression param = null)
         {
             // TODO: Replace db param here?
-            param = param ?? Expression.Parameter(typeof (TArgs), "args");
-            var transformedExpr = Expression.Lambda(Expression.Convert(baseExpr.Body, typeof(TResult)), baseExpr.Parameters[0], Expression.Parameter(typeof (TContext), "base"));
+            param = param ?? Expression.Parameter(typeof(TArgs), "args");
+            var transformedExpr = Expression.Lambda(
+                Expression.Convert(baseExpr.Body, typeof(TResult)), 
+                baseExpr.Parameters[0], 
+                Expression.Parameter(typeof(TContext), "base"));
             var quoted = Expression.Quote(transformedExpr);
             var final = Expression.Lambda<Func<TArgs, Expression<Func<TContext, TContext, TResult>>>>(quoted, param);
             return final.Compile();
         }
 
-        private static Func<TArgs, TMutReturn, Expression<Func<TContext, TContext, TResult>>> GetFinalMutationFunc<TContext, TArgs, TMutReturn, TResult>(Expression<Func<TContext, TResult>> baseExpr, ParameterExpression argParam, ParameterExpression retParam)
+        private static Func<TArgs, TMutReturn, Expression<Func<TContext, TContext, TResult>>> GetFinalMutationFunc<TContext, TArgs, TMutReturn, TResult>(
+            Expression<Func<TContext, TResult>> baseExpr, 
+            ParameterExpression argParam, 
+            ParameterExpression retParam)
         {
             // TODO: Replace db param here?
-            argParam = argParam ?? Expression.Parameter(typeof (TArgs), "args");
-            var transformedExpr = Expression.Lambda(Expression.Convert(baseExpr.Body, typeof(TResult)), baseExpr.Parameters[0], Expression.Parameter(typeof (TContext), "base"));
+            argParam = argParam ?? Expression.Parameter(typeof(TArgs), "args");
+            var transformedExpr = Expression.Lambda(
+                Expression.Convert(baseExpr.Body, typeof(TResult)), 
+                baseExpr.Parameters[0], 
+                Expression.Parameter(typeof(TContext), "base"));
             var quoted = Expression.Quote(transformedExpr);
-            var final = Expression.Lambda<Func<TArgs, TMutReturn, Expression<Func<TContext, TContext, TResult>>>>(quoted, argParam, retParam);
+            var final = Expression.Lambda<Func<TArgs, TMutReturn, Expression<Func<TContext, TContext, TResult>>>>(
+                quoted, 
+                argParam, 
+                retParam);
             return final.Compile();
         }
-
+        
         // Transform  db => db.Entities.Where(args)  into  args => db => db.Entities.Where(args)
-        public static GraphQLFieldBuilder<TContext, TEntity> AddListField<TContext, TEntity>(this GraphQLSchema<TContext> context, string name, Expression<Func<TContext, IEnumerable<TEntity>>> queryableGetter)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddListField<TContext, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, IEnumerable<TEntity>>> queryableGetter)
         {
-            return context.AddFieldInternal(name, GetFinalQueryFunc<TContext, object, IEnumerable<TEntity>>(queryableGetter), ResolutionType.ToList);
+            return context.AddFieldInternal(
+                name, 
+                GetFinalQueryFunc<TContext, object, IEnumerable<TEntity>>(queryableGetter), 
+                ResolutionType.ToList);
         }
 
         // Transform  db => db.Entities.Where(args)  into  args => db => db.Entities.Where(args)
-        public static GraphQLFieldBuilder<TContext, TEntity> AddField<TContext, TEntity>(this GraphQLSchema<TContext> context, string name, Expression<Func<TContext, TEntity>> queryableGetter)
+        public static GraphQLFieldBuilder<TContext, TExecutionParameters, TEntity> AddField<TContext, TEntity, TExecutionParameters>(
+            this GraphQLSchema<TContext, TExecutionParameters> context, 
+            string name, 
+            Expression<Func<TContext, TEntity>> queryableGetter)
         {
             var info = GetQueryInfo(queryableGetter);
             if (info.ResolutionType != ResolutionType.Unmodified)
-                return context.AddFieldInternal(name, GetFinalQueryFunc<TContext, object, IEnumerable<TEntity>>(info.BaseQuery), info.ResolutionType);
+                return context.AddFieldInternal(
+                    name, 
+                    GetFinalQueryFunc<TContext, object, IEnumerable<TEntity>>(info.BaseQuery), 
+                    info.ResolutionType);
             return context.AddUnmodifiedFieldInternal(name, GetFinalQueryFunc<TContext, object, TEntity>(info.OriginalQuery));
         }
 
@@ -120,11 +284,11 @@ namespace GraphQL.Net
 
         private static QueryInfo<TContext, TEntity> GetQueryInfo<TContext, TEntity>(Expression<Func<TContext, TEntity>> queryableGetter)
         {
-            var info = new QueryInfo<TContext, TEntity> {OriginalQuery = queryableGetter, ResolutionType = ResolutionType.Unmodified};
+            var info = new QueryInfo<TContext, TEntity> { OriginalQuery = queryableGetter, ResolutionType = ResolutionType.Unmodified };
             var mce = queryableGetter.Body as MethodCallExpression;
             if (mce == null) return info;
 
-            if (mce.Method.DeclaringType != typeof (Queryable)) return info; // TODO: Enumerable?
+            if (mce.Method.DeclaringType != typeof(Queryable)) return info; // TODO: Enumerable?
             if (!mce.Method.IsStatic) return info;
 
             switch (mce.Method.Name)
@@ -142,7 +306,7 @@ namespace GraphQL.Net
             var baseQueryable = mce.Arguments[0];
             if (mce.Arguments.Count > 1)
             {
-                baseQueryable = Expression.Call(typeof (Queryable), "Where", new[] {typeof (TEntity)}, baseQueryable, mce.Arguments[1]);
+                baseQueryable = Expression.Call(typeof(Queryable), "Where", new[] { typeof(TEntity) }, baseQueryable, mce.Arguments[1]);
             }
 
             info.BaseQuery = Expression.Lambda<Func<TContext, IEnumerable<TEntity>>>(baseQueryable, queryableGetter.Parameters[0]);

--- a/Tests.EF/Tests.EF.csproj
+++ b/Tests.EF/Tests.EF.csproj
@@ -47,6 +47,9 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/Tests/GenericTests.cs
+++ b/Tests/GenericTests.cs
@@ -7,85 +7,85 @@ namespace Tests
 {
     public static class GenericTests
     {
-        public static void LookupSingleEntity<TContext>(GraphQL<TContext> gql)
+        public static void LookupSingleEntity<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, name } }");
             Test.DeepEquals(results, "{ user: { id: 1, name: 'Joe User' } }");
         }
 
-        public static void AliasOneField<TContext>(GraphQL<TContext> gql)
+        public static void AliasOneField<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { idAlias : id, name } }");
             Test.DeepEquals(results, "{ user: { idAlias: 1, name: 'Joe User' } }");
         }
 
-        public static void NestedEntity<TContext>(GraphQL<TContext> gql)
+        public static void NestedEntity<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, account { id, name } } }");
             Test.DeepEquals(results, "{ user: { id: 1, account: { id: 1, name: 'My Test Account' } } }");
         }
 
-        public static void NoUserQueryReturnsNull<TContext>(GraphQL<TContext> gql)
+        public static void NoUserQueryReturnsNull<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:0) { id, account { id, name } } }");
             Test.DeepEquals(results, "{ user: null }");
         }
 
-        public static void CustomFieldSubQuery<TContext>(GraphQL<TContext> gql)
+        public static void CustomFieldSubQuery<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, accountPaid } }");
             Test.DeepEquals(results, "{ user: { id: 1, accountPaid: true } }");
         }
 
-        public static void CustomFieldSubQueryUsingContext<TContext>(GraphQL<TContext> gql)
+        public static void CustomFieldSubQueryUsingContext<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, total } }");
             Test.DeepEquals(results, "{ user: { id: 1, total: 2 } }");
         }
 
-        public static void List<TContext>(GraphQL<TContext> gql)
+        public static void List<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ users { id, name } }");
             Test.DeepEquals(results, "{ users: [{ id: 1, name: 'Joe User'}, { id: 2, name: 'Late Paying User' }] }");
         }
 
-        public static void ListTypeIsList<TContext>(GraphQL<TContext> gql)
+        public static void ListTypeIsList<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var users = gql.ExecuteQuery("{ users { id, name } }")["users"];
             Assert.AreEqual(users.GetType(), typeof(List<IDictionary<string, object>>));
         }
 
-        public static void NestedEntityList<TContext>(GraphQL<TContext> gql)
+        public static void NestedEntityList<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ account(id:1) { id, users { id, name } } }");
             Test.DeepEquals(results, "{ account: { id: 1, users: [{ id: 1, name: 'Joe User' }] } }");
         }
 
-        public static void PostField<TContext>(GraphQL<TContext> gql)
+        public static void PostField<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, abc } }");
             Test.DeepEquals(results, "{ user: { id: 1, abc: 'easy as 123' } }");
         }
 
-        public static void PostFieldSubQuery<TContext>(GraphQL<TContext> gql)
+        public static void PostFieldSubQuery<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { sub { id } } }");
             Test.DeepEquals(results, "{ user: { sub: { id: 1 } } }");
         }
 
-        public static void TypeName<TContext>(GraphQL<TContext> gql)
+        public static void TypeName<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, __typename } }");
             Test.DeepEquals(results, "{ user: { id: 1, __typename: 'User' } }");
         }
 
-        public static void DateTimeFilter<TContext>(GraphQL<TContext> gql)
+        public static void DateTimeFilter<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ accountPaidBy(paid: { year: 2016 month: 1 day: 1 }) { id } }");
             Test.DeepEquals(results, "{ accountPaidBy: { id: 1 } }");
         }
 
-        public static void EnumerableSubField<TContext>(GraphQL<TContext> gql)
+        public static void EnumerableSubField<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ account(id:1) { activeUsers { id, name } } }");
             Test.DeepEquals(results, "{ account: { activeUsers: [{ id: 1, name: 'Joe User' }] } }");
@@ -94,7 +94,7 @@ namespace Tests
             Test.DeepEquals(results2, "{ account: { activeUsers: [] } }");
         }
 
-        public static void SimpleMutation<TContext>(GraphQL<TContext> gql)
+        public static void SimpleMutation<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("mutation { mutate(id:1,newVal:5) { id, value } }");
             Test.DeepEquals(results, "{ mutate: { id: 1, value: 5 } }");
@@ -103,25 +103,25 @@ namespace Tests
             Test.DeepEquals(results2, "{ mutate: { id: 1, value: 123 } }");
         }
 
-        public static void MutationWithReturn<TContext>(GraphQL<TContext> gql)
+        public static void MutationWithReturn<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("mutation { addMutate(newVal: 7) { value } }");
             Test.DeepEquals(results, "{ addMutate: { value: 7 } }");
         }
 
-        public static void NullPropagation<TContext>(GraphQL<TContext> gql)
+        public static void NullPropagation<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { id, nullRef { id } } }");
             Test.DeepEquals(results, "{ user: { id: 1, nullRef: null } }");
         }
 
-        public static void GuidField<TContext>(GraphQL<TContext> gql)
+        public static void GuidField<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ account(id:1) { id, someGuid } }");
             Test.DeepEquals(results, "{ account: { id: 1, someGuid: '00000000-0000-0000-0000-000000000000' } }");
         }
 
-        public static void GuidParameter<TContext>(GraphQL<TContext> gql)
+        public static void GuidParameter<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ accountsByGuid(guid:\"00000000-0000-0000-0000-000000000000\") { id, someGuid } }");
             Test.DeepEquals(results, @"{
@@ -132,13 +132,13 @@ namespace Tests
                                        }");
         }
 
-        public static void ByteArrayParameter<TContext>(GraphQL<TContext> gql)
+        public static void ByteArrayParameter<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ account(id:1) { id, byteArray } }");
             Test.DeepEquals(results, "{ account: { id: 1, byteArray: 'AQIDBA==' } }"); // [1, 2, 3, 4] serialized to base64 by Json.NET
         }
 
-        public static void ChildListFieldWithParameters<TContext>(GraphQL<TContext> gql)
+        public static void ChildListFieldWithParameters<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ account(id:1) { id, name, usersWithActive(active:true) { id, name } } }");
             Test.DeepEquals(results, "{ account: { id: 1, name: 'My Test Account', usersWithActive: [{ id: 1, name: 'Joe User' }] } }");
@@ -147,7 +147,7 @@ namespace Tests
             Test.DeepEquals(results, "{ account: { id: 1, name: 'My Test Account', usersWithActive: [] } }");
         }
 
-        public static void ChildFieldWithParameters<TContext>(GraphQL<TContext> gql)
+        public static void ChildFieldWithParameters<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ account(id:1) { id, name, firstUserWithActive(active:true) { id, name } } }");
             Test.DeepEquals(results, "{ account: { id: 1, name: 'My Test Account', firstUserWithActive: { id: 1, name: 'Joe User' } } }");
@@ -156,7 +156,7 @@ namespace Tests
             Test.DeepEquals(results, "{ account: { id: 1, name: 'My Test Account', firstUserWithActive: null } }");
         }
 
-        public static void Fragements<TContext>(GraphQL<TContext> gql)
+        public static void Fragements<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery(
                 "{ heros { name, __typename, ...human, ...stormtrooper, ...droid } }, " +
@@ -172,7 +172,7 @@ namespace Tests
                 );
         }
 
-        public static void InlineFragements<TContext>(GraphQL<TContext> gql)
+        public static void InlineFragements<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery(
                 "{ heros { name, __typename, ... on Human { height }, ... on Stormtrooper { specialization }, " +
@@ -186,7 +186,7 @@ namespace Tests
                 );
         }
 
-        public static void FragementWithMultiLevelInheritance<TContext>(GraphQL<TContext> gql)
+        public static void FragementWithMultiLevelInheritance<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ heros { name, __typename, ... on Stormtrooper { height, specialization } } }");
             Test.DeepEquals(
@@ -198,7 +198,7 @@ namespace Tests
                 );
         }
 
-        public static void InlineFragementWithoutTypenameField<TContext>(GraphQL<TContext> gql)
+        public static void InlineFragementWithoutTypenameField<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ heros { name, ... on Stormtrooper { height, specialization } } }");
             Test.DeepEquals(
@@ -210,7 +210,7 @@ namespace Tests
                 );
         }
 
-        public static void InlineFragementWithoutTypenameFieldWithoutOtherFields<TContext>(GraphQL<TContext> gql)
+        public static void InlineFragementWithoutTypenameFieldWithoutOtherFields<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery("{ heros { ... on Stormtrooper { height, specialization } } }");
             Test.DeepEquals(
@@ -222,7 +222,7 @@ namespace Tests
                 );
         }
 
-        public static void FragementWithoutTypenameField<TContext>(GraphQL<TContext> gql)
+        public static void FragementWithoutTypenameField<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery(
                 "{ heros { name, ...stormtrooper } }, fragment stormtrooper on Stormtrooper { height, specialization } ");
@@ -235,7 +235,7 @@ namespace Tests
                 );
         }
 
-        public static void FragementWithMultipleTypenameFields<TContext>(GraphQL<TContext> gql)
+        public static void FragementWithMultipleTypenameFields<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery(
                 "{ heros { name, ...stormtrooper, __typename } }, fragment stormtrooper on Stormtrooper { height, specialization, __typename } ");
@@ -248,7 +248,7 @@ namespace Tests
                 );
         }
 
-        public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment<TContext>(GraphQL<TContext> gql)
+        public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql)
         {
             var results = gql.ExecuteQuery(
                 "{ heros { ...stormtrooper, __typename, ... on Human {name}, ... on Droid {name}}}, fragment stormtrooper on Stormtrooper { name, height, specialization, __typename } ");
@@ -259,6 +259,21 @@ namespace Tests
                 "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper', __typename: 'Stormtrooper'}, " +
                 "{ __typename: 'Droid', name: 'R2-D2'} ] }"
                 );
+        }
+        
+        public static void SimpleMutationWithQueryExecutionParams<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql, TExecutionParameters queryExecParams)
+        {
+            var results = gql.ExecuteQuery("mutation { mutate(id:1,newVal:5) { id, value } }", queryExecParams);
+            Test.DeepEquals(results, "{ mutate: { id: 1, value: 5 } }");
+
+            var results2 = gql.ExecuteQuery("mutation { mutate(id:1,newVal:123) { id, value } }", queryExecParams);
+            Test.DeepEquals(results2, "{ mutate: { id: 1, value: 123 } }");
+        }
+
+        public static void MutationWithReturnAndExceutionParameters<TContext, TExecutionParameters>(GraphQL<TContext, TExecutionParameters> gql, TExecutionParameters queryExecParams)
+        {
+            var results = gql.ExecuteQuery("mutation { addMutate(newVal: 7) { value } }", queryExecParams);
+            Test.DeepEquals(results, "{ addMutate: { value: 7 } }");
         }
     }
 }

--- a/Tests/InMemoryExecutionTests.cs
+++ b/Tests/InMemoryExecutionTests.cs
@@ -39,7 +39,11 @@ namespace Tests
         [Test] public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithMultipleTypenameFields() => GenericTests.FragementWithMultipleTypenameFields(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment() => GenericTests.FragementWithMultipleTypenameFieldsMixedWithInlineFragment(MemContext.CreateDefaultContext());
-
+        [Test]
+        public static void SimpleMutationWithQueryExecutionParams() => GenericTests.SimpleMutationWithQueryExecutionParams(MemContext.CreateContextWithQueryExecutionParams(), MemContext.CreateQueryExecutionParameters());
+        [Test]
+        public static void MutationWithReturnAndExceutionParameters() => GenericTests.MutationWithReturnAndExceutionParameters(MemContext.CreateContextWithQueryExecutionParams(), MemContext.CreateQueryExecutionParameters());
+        
         [Test]
         public void AddAllFields()
         {


### PR DESCRIPTION
Hi,
as explained in [https://github.com/ckimes89/graphql-net/pull/57](https://github.com/ckimes89/graphql-net/pull/57), we use graphql-net in a web API application.
The schema is built once and for every request `ExecuteQuery` is called with a context which is injected into the controller. This works pretty well for queries.
We have a service layer containing the business logic for create/update/delete actions. Mutations simply consist of method calls of a service which is injected into the controller as well.
Currently, in mutation actions the arugments object and the context are accessible.
It seems not a good idea to make those services accessible through any of these objects.
Therefore, this PR introduces a thid object which is (optionally) passed to mutation actions.

No breaking API changes are introduced, there is another `AddMutation` overload variation:
```csharp
schema.AddMutation("mutate",
   new { id = 0, newVal = 0 },
   (db, args, execParams) =>
   {
      var mutateMe = db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id);
      execParams.MutateMeService.Update(execParams.authenticatedUserId, mutateMe, args.newVal);
      db.SaveChanges();
   },
   (db, args) => db.MutateMes.AsQueryable().FirstOrDefault(a => a.Id == args.id));
```

Please let me know what you think about the changes :)