### PR TITLE
Parse int and double values using invariant culture

### DIFF
--- a/GraphQL.Parser/Parsing/Parser.fs
+++ b/GraphQL.Parser/Parsing/Parser.fs
@@ -140,6 +140,21 @@ let variableName =
 let variable =
     %% +.variableName -%> Variable
 
+
+(**
+
+Helper functions to parse int with fix culture.
+
+*)
+let int64ParseLocalized v = Int64.Parse(v, CultureInfo.CreateSpecificCulture("en-US"))
+
+(**
+
+Helper functions to parse double with fix culture.
+
+*)
+let doubleParseLocalized v = Double.Parse(v, CultureInfo.CreateSpecificCulture("en-US"))
+
 (**
 
 Both float and int parsers can be implemented to match the spec
@@ -162,9 +177,9 @@ let numericValue =
             |> sprintf "Non-zero numeric literal (%s) may not start with a 0"
             |> fail
         else if literal.IsInteger then
-            literal.String |> Int64.Parse |> IntValue |> preturn
+            literal.String |> int64ParseLocalized |> IntValue |> preturn
         else
-            literal.String |> Double.Parse |> FloatValue |> preturn
+            literal.String |> doubleParseLocalized |> FloatValue |> preturn
 
 (**
 

--- a/GraphQL.Parser/Parsing/Parser.fs
+++ b/GraphQL.Parser/Parsing/Parser.fs
@@ -146,14 +146,14 @@ let variable =
 Helper functions to parse int with fix culture.
 
 *)
-let int64ParseLocalized v = Int64.Parse(v, CultureInfo.CreateSpecificCulture("en-US"))
+let int64ParseLocalized v = Int64.Parse(v, CultureInfo.InvariantCulture)
 
 (**
 
 Helper functions to parse double with fix culture.
 
 *)
-let doubleParseLocalized v = Double.Parse(v, CultureInfo.CreateSpecificCulture("en-US"))
+let doubleParseLocalized v = Double.Parse(v, CultureInfo.InvariantCulture)
 
 (**
 


### PR DESCRIPTION
I ran into an issue with parsing doubles. 

In a query like this:
` anyQuery(doubleArgument: 0.5) {...}
`
The argument `doubleArgument` might be parsed to the value "5" if a culture with decimal comma is used.
(see [this SO-thread](http://stackoverflow.com/questions/1354924/how-do-i-parse-a-string-with-a-decimal-point-to-a-double))

This PR fixes this issue.