### PR TITLE
Fix: missing "}" in Executing Queries in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ user(id:1) {
         paid
     }
     totalUsers
-}";
+}}";
 
 var gql = new GraphQL<TestContext>(schema);
 var dict = gql.ExecuteQuery(query);


### PR DESCRIPTION
I added "}" to the query variable in the Executing Query section.