### PR TITLE
Support development under OSX (mono)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ bld/
 # Roslyn cache directories
 *.ide/
 .vs/
+.idea/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/

--- a/GraphQL.Parser.Test/GraphQL.Parser.Test.fsproj
+++ b/GraphQL.Parser.Test/GraphQL.Parser.Test.fsproj
@@ -51,6 +51,9 @@
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
+      <PropertyGroup Condition="Exists('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/Microsoft F#/v4.0/Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/Microsoft F#/v4.0/Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
     </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />

--- a/GraphQL.Parser/GraphQL.Parser.fsproj
+++ b/GraphQL.Parser/GraphQL.Parser.fsproj
@@ -49,6 +49,9 @@
       <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets')">
         <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
       </PropertyGroup>
+      <PropertyGroup Condition="Exists('/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/Microsoft F#/v4.0/Microsoft.FSharp.Targets')">
+        <FSharpTargetsPath>/Library/Frameworks/Mono.framework/Versions/Current/lib/mono/Microsoft F#/v4.0/Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
     </Otherwise>
   </Choose>
   <Import Project="$(FSharpTargetsPath)" />


### PR DESCRIPTION
Updates project files to support development under osx (mono / Rider).

Note: Tests of project `Tests.EF` can't be executed: 
```
Tests.EF.EntityFrameworkExecutionTests

System.DllNotFoundException : SQLite.Interop.dll
  at (wrapper managed-to-native) System.Data.SQLite.UnsafeNativeMethods:sqlite3_config_none (System.Data.SQLite.SQLiteConfigOpsEnum)
  at System.Data.SQLite.SQLite3.StaticIsInitialized () [0x0001d] in <0b3ed5ac83ff44b5a5ea64245b286bfb>:0 
  at System.Data.SQLite.SQLiteLog.Initialize () [0x00000] in <0b3ed5ac83ff44b5a5ea64245b286bfb>:0 
  at System.Data.SQLite.SQLiteConnection..ctor (System.String connectionString, System.Boolean parseViaFramework) [0x00021] in <0b3ed5ac83ff44b5a5ea64245b286bfb>:0 
  at System.Data.SQLite.SQLiteConnection..ctor (System.String connectionString) [0x00000] in <0b3ed5ac83ff44b5a5ea64245b286bfb>:0 
  at System.Data.SQLite.SQLiteConnection..ctor () [0x00000] in <0b3ed5ac83ff44b5a5ea64245b286bfb>:0 
  at (wrapper remoting-invoke-with-check) System.Data.SQLite.SQLiteConnection:.ctor ()
  at System.Data.SQLite.EF6.SQLiteProviderFactory.CreateConnection () [0x00006] in <7147898d89ef4b7daf4cf0fa76993965>:0 
  at System.Data.Entity.Internal.LazyInternalConnection.CreateConnectionFromProviderName (System.String providerInvariantName) [0x0000c] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.LazyInternalConnection.InitializeFromConnectionStringSetting (System.Configuration.ConnectionStringSettings appConfigConnection) [0x0003b] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.LazyInternalConnection.TryInitializeFromAppConfig (System.String name, System.Data.Entity.Internal.AppConfig config) [0x0000b] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.LazyInternalConnection.Initialize () [0x0005b] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.LazyInternalConnection.get_ProviderName () [0x00000] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.LazyInternalContext.get_ProviderName () [0x00000] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.DefaultModelCacheKeyFactory.Create (System.Data.Entity.DbContext context) [0x0002b] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.LazyInternalContext.InitializeContext () [0x0009b] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.InternalContext.Initialize () [0x00000] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.InternalContext.GetEntitySetAndBaseTypeForType (System.Type entityType) [0x00000] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.Linq.InternalSet`1[TEntity].Initialize () [0x0000e] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Internal.Linq.InternalSet`1[TEntity].get_InternalContext () [0x00000] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Data.Entity.Infrastructure.DbQuery`1[TResult].System.Linq.IQueryable.get_Provider () [0x00016] in <000f54522ad145bf987b3043022f9799>:0 
  at System.Linq.Queryable.Any[TSource] (System.Linq.IQueryable`1[T] source) [0x00011] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/referencesource/System.Core/System/Linq/IQueryable.cs:1025 
  at Tests.EF.EntityFrameworkExecutionTests.Init () [0x0000e] in...graphql-net/Tests.EF/EntityFrameworkExecutionTests.cs:21 
  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00038] in /private/tmp/source-mono-4.8.0/bockbuild-mono-4.8.0-branch/profiles/mono-mac-xamarin/build-root/mono-x86/mcs/class/corlib/System.Reflection/MonoMethod.cs:305

```