### PR TITLE
Add expression option to use base type.

### DIFF
--- a/GraphQL.Net/Executor.cs
+++ b/GraphQL.Net/Executor.cs
@@ -35,7 +35,7 @@ namespace GraphQL.Net
             }
             
             var queryExecSelections = query.Selections.Values();
-            var selector = GetSelector(schema, field.Type, queryExecSelections, schema.GetOptionsForQueryable(queryType));
+            var selector = GetSelector(schema, field.Type, queryExecSelections, expressionOptions);
 
             if (field.ResolutionType != ResolutionType.Unmodified)
             {

--- a/GraphQL.Net/Executor.cs
+++ b/GraphQL.Net/Executor.cs
@@ -26,6 +26,14 @@ namespace GraphQL.Net
             // sniff queryable provider to determine how selector should be built
             var dummyQuery = replaced.Compile().DynamicInvoke(context, null);
             var queryType = dummyQuery.GetType();
+            var expressionOptions = schema.GetOptionsForQueryable(queryType)
+
+            if (expressionOptions.UseBaseType)
+            {
+                queryType = queryType.BaseType;
+                expressionOptions = schema.GetOptionsForQueryable(queryType);
+            }
+            
             var queryExecSelections = query.Selections.Values();
             var selector = GetSelector(schema, field.Type, queryExecSelections, schema.GetOptionsForQueryable(queryType));
 

--- a/GraphQL.Net/Executor.cs
+++ b/GraphQL.Net/Executor.cs
@@ -26,7 +26,7 @@ namespace GraphQL.Net
             // sniff queryable provider to determine how selector should be built
             var dummyQuery = replaced.Compile().DynamicInvoke(context, null);
             var queryType = dummyQuery.GetType();
-            var expressionOptions = schema.GetOptionsForQueryable(queryType)
+            var expressionOptions = schema.GetOptionsForQueryable(queryType);
 
             if (expressionOptions.UseBaseType)
             {

--- a/GraphQL.Net/ExpressionOptions.cs
+++ b/GraphQL.Net/ExpressionOptions.cs
@@ -4,17 +4,20 @@ namespace GraphQL.Net
 {
     internal class ExpressionOptions
     {
-        public ExpressionOptions(Func<Type, bool> validForQueryType, bool castAssignment = false, bool nullCheckLists = false, bool typeCheckInheritance = false)
+        public ExpressionOptions(Func<Type, bool> validForQueryType, bool castAssignment = false,
+            bool nullCheckLists = false, bool typeCheckInheritance = false, bool useBaseType = false)
         {
             ValidForQueryType = validForQueryType;
             CastAssignment = castAssignment;
             NullCheckLists = nullCheckLists;
+            UseBaseType = useBaseType;
             TypeCheckInheritance = typeCheckInheritance;
         }
 
         public Func<Type, bool> ValidForQueryType { get; }
         public bool CastAssignment { get; }
         public bool NullCheckLists { get; }
+        public bool UseBaseType { get; }
         public bool TypeCheckInheritance { get; }
     }
 }


### PR DESCRIPTION
I ran into an issue when executing queries against mutation results with Entity Framework when a mutation returns a EF proxy.

Looking at `Executor` (line 19ff):
```
public static object Execute
    (GraphQLSchema<TContext> schema, TContext context, GraphQLField field, ExecSelection<Info> query)
{
    var mutReturn = field.RunMutation(context, query.Arguments.Values());

    var queryableFuncExpr = field.GetExpression(query.Arguments.Values(), mutReturn);
    var replaced = (LambdaExpression)ParameterReplacer.Replace(queryableFuncExpr, queryableFuncExpr.Parameters[0], GraphQLSchema<TContext>.DbParam);

    // sniff queryable provider to determine how selector should be built
    var dummyQuery = replaced.Compile().DynamicInvoke(context, null);
    var queryType = dummyQuery.GetType();
```

In this case the `queryType` is `System.Data.Entity.DynamicProxies`, but we are interested in the `queryType.BaseType`.

This PR adds an expression option to handle this.
