### PR TITLE
Bug fix

### DIFF
--- a/GraphQL.Parser/SchemaTools/TypeHandlers.fs
+++ b/GraphQL.Parser/SchemaTools/TypeHandlers.fs
@@ -495,7 +495,10 @@ type RootTypeHandler(metaHandler : IMetaTypeHandler) as this =
 
     member this.ResolveEnumValueByName(name) =
         initialize()
-        enumValuesByName.TryFind(name)
+        let res = enumValuesByName.TryFind(name)
+        if res = None then
+            invalid <| sprintf "The enum value name ``%s'' is not defined" name
+        res
 
     member this.TypeDictionary =
         initialize()

--- a/Tests.EF/EntityFrameworkExecutionTests.cs
+++ b/Tests.EF/EntityFrameworkExecutionTests.cs
@@ -121,6 +121,7 @@ namespace Tests.EF
             schema.AddType<Sub>().AddField(s => s.Id);
             schema.AddListField("users", db => db.Users);
             schema.AddField("user", new { id = 0 }, (db, args) => db.Users.FirstOrDefault(u => u.Id == args.id));
+            schema.AddField("userByName", new { name = "" }, (db, args) => db.Users.FirstOrDefault(u => u.Name == args.name));
         }
 
         private static string GetAbcPostField() => "easy as 123"; // mimic an in-memory function
@@ -275,6 +276,9 @@ namespace Tests.EF
             var results = gql.ExecuteQuery("{ user(id:1) { id, name } }");
             Test.DeepEquals(results, "{ user: { id: 1, name: 'Joe User' } }");
         }
+
+        [Test]
+        public void LookupSingleEntityError() => GenericTests.LookupSingleEntityError(CreateDefaultContext());
 
         class Sub
         {

--- a/Tests/GenericTests.cs
+++ b/Tests/GenericTests.cs
@@ -288,14 +288,7 @@ namespace Tests
 
         public static void LookupSingleEntityError<TContext>(GraphQL<TContext> gql)
         {
-            try
-            {
-                var results = gql.ExecuteQuery("{ userByName(name:JoeUser) { id, name } }");
-                Assert.Fail();
-            }
-            catch (ValidationException)
-            {
-            }
+            Assert.Throws<ValidationException>(() => gql.ExecuteQuery("{ userByName(name:JoeUser) { id, name } }"));
         }
     }
 }

--- a/Tests/GenericTests.cs
+++ b/Tests/GenericTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using GraphQL.Net;
+using GraphQL.Parser;
 using NUnit.Framework;
 
 namespace Tests
@@ -12,7 +13,7 @@ namespace Tests
             var results = gql.ExecuteQuery("{ user(id:1) { id, name } }");
             Test.DeepEquals(results, "{ user: { id: 1, name: 'Joe User' } }");
         }
-
+               
         public static void AliasOneField<TContext>(GraphQL<TContext> gql)
         {
             var results = gql.ExecuteQuery("{ user(id:1) { idAlias : id, name } }");
@@ -283,6 +284,18 @@ namespace Tests
                 "{ name: 'FN-2187', height: 4.9, specialization: 'Imperial Snowtrooper', __typename: 'Stormtrooper'}, " +
                 "{ __typename: 'Droid', name: 'R2-D2'} ] }"
                 );
+        }
+
+        public static void LookupSingleEntityError<TContext>(GraphQL<TContext> gql)
+        {
+            try
+            {
+                var results = gql.ExecuteQuery("{ userByName(name:JoeUser) { id, name } }");
+                Assert.Fail();
+            }
+            catch (ValidationException)
+            {
+            }
         }
     }
 }

--- a/Tests/InMemoryExecutionTests.cs
+++ b/Tests/InMemoryExecutionTests.cs
@@ -41,6 +41,7 @@ namespace Tests
         [Test] public static void InlineFragementWithoutTypenameFieldWithoutOtherFields() => GenericTests.InlineFragementWithoutTypenameFieldWithoutOtherFields(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithMultipleTypenameFields() => GenericTests.FragementWithMultipleTypenameFields(MemContext.CreateDefaultContext());
         [Test] public static void FragementWithMultipleTypenameFieldsMixedWithInlineFragment() => GenericTests.FragementWithMultipleTypenameFieldsMixedWithInlineFragment(MemContext.CreateDefaultContext());
+        [Test] public void LookupSingleEntityError() => GenericTests.LookupSingleEntityError(MemContext.CreateDefaultContext());
 
         [Test]
         public void AddAllFields()

--- a/Tests/MemContext.cs
+++ b/Tests/MemContext.cs
@@ -133,6 +133,7 @@ namespace Tests
             schema.AddType<Sub>().AddField(s => s.Id);
             schema.AddListField("users", db => db.Users.AsQueryable());
             schema.AddField("user", new { id = 0 }, (db, args) => db.Users.AsQueryable().FirstOrDefault(u => u.Id == args.id));
+            schema.AddField("userByName", new { name = "" }, (db, args) => db.Users.AsQueryable().FirstOrDefault(u => u.Name == args.name));
         }
 
         private static string GetAbcPostField() => "easy as 123"; // mimic an in-memory function


### PR DESCRIPTION
Bugfix
====

Null reference exception is thrown when invalid/unknown enum value name is provided in a query